### PR TITLE
Add automatic dominator usage on big creeps

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -1,741 +1,517 @@
-local agent_script = { ui = {} }
+local commander = {}
 
---[[
-    Unit Commander (rewrite)
-    ------------------------
-    Controls all allied units except the hero and courier. Provides a
-    configuration menu, enlarged debug overlays, and automatic spell usage for
-    neutral creeps using UCZone API v2 friendly helpers.
-]]
-
--------------------------------------------------------------------------------
--- Runtime state
--------------------------------------------------------------------------------
-local runtime = {
+local state = {
     hero = nil,
-    hero_owner_id = nil,
     team = nil,
     player = nil,
     player_id = nil,
-    config = nil,
-    agents = {},
-    threat_expiry = {},
-    menu_ready = false,
-    debug_font = nil,
+    units = {},
+    manual_lock = {},
+    last_dominate_attempt = 0,
 }
 
-local STATES = {
-    FOLLOW = "FOLLOW",
-    ENGAGE = "ENGAGE",
-    FARM = "FARM",
-    MANUAL = "MANUAL",
+local FOLLOW_DISTANCE = 425
+local ATTACK_RADIUS = 1000
+local ORDER_COOLDOWN = 0.25
+local CAST_COOLDOWN = 0.35
+local MANUAL_SUPPRESSION = 0.9
+
+local DOMINATOR_ITEMS = {
+    "item_helm_of_the_dominator",
+    "item_helm_of_the_overlord",
 }
 
--------------------------------------------------------------------------------
--- Utility helpers
--------------------------------------------------------------------------------
-local function ResetRuntime()
-    runtime.hero = nil
-    runtime.hero_owner_id = nil
-    runtime.team = nil
-    runtime.player = nil
-    runtime.player_id = nil
-    runtime.config = nil
-    runtime.agents = {}
-    runtime.threat_expiry = {}
-    runtime.debug_font = nil
+local DOMINATOR_PRIORITY = {
+    npc_dota_neutral_black_dragon = 500,
+    npc_dota_neutral_granite_golem = 480,
+    npc_dota_neutral_elder_jungle_stalker = 460,
+    npc_dota_neutral_prowler_acolyte = 450,
+    npc_dota_neutral_rock_golem = 440,
+    npc_dota_neutral_big_thunder_lizard = 420,
+    npc_dota_neutral_dark_troll_warlord = 350,
+    npc_dota_neutral_enraged_wildkin = 340,
+    npc_dota_neutral_polar_furbolg_ursa_warrior = 330,
+    npc_dota_neutral_polar_furbolg_champion = 330,
+    npc_dota_neutral_satyr_hellcaller = 320,
+    npc_dota_neutral_centaur_khan = 310,
+    npc_dota_neutral_ogre_magi = 300,
+    npc_dota_neutral_ogre_mauler = 295,
+    npc_dota_neutral_mud_golem = 250,
+    npc_dota_neutral_fel_beast = 240,
+    npc_dota_neutral_wildkin = 230,
+    npc_dota_neutral_harpy_storm = 220,
+    npc_dota_neutral_alpha_wolf = 215,
+}
+
+local ANCIENT_NEUTRALS = {
+    npc_dota_neutral_black_dragon = true,
+    npc_dota_neutral_granite_golem = true,
+    npc_dota_neutral_rock_golem = true,
+    npc_dota_neutral_elder_jungle_stalker = true,
+    npc_dota_neutral_prowler_acolyte = true,
+    npc_dota_neutral_big_thunder_lizard = true,
+}
+
+local ability_data = {}
+
+local function register_ability(name, data)
+    ability_data[name] = data
+    if data.aliases then
+        for _, alias in ipairs(data.aliases) do
+            ability_data[alias] = data
+        end
+    end
 end
 
-local function IsValidHandle(handle)
-    if not handle then
-        return false
-    end
+register_ability("mud_golem_hurl_boulder", {
+    type = "target",
+    allow_neutrals = true,
+    min_interval = 0.2,
+    message = "boulder",
+    aliases = {
+        "granite_golem_hurl_boulder",
+        "ancient_rock_golem_hurl_boulder",
+    },
+})
 
-    local t = type(handle)
-    if t ~= "userdata" and t ~= "table" then
-        return false
-    end
+register_ability("dark_troll_warlord_ensnare", {
+    type = "target",
+    allow_neutrals = true,
+})
 
-    local is_null = handle.IsNull
-    if type(is_null) == "function" then
-        local ok, result = pcall(is_null, handle)
-        if ok and result then
-            return false
-        end
-    end
+register_ability("dark_troll_warlord_raise_dead", {
+    type = "no_target",
+    always = true,
+    min_interval = 8,
+})
 
-    return true
+register_ability("forest_troll_high_priest_heal", {
+    type = "ally",
+    prefer_hero = true,
+    ally_max_hp = 0.92,
+})
+
+register_ability("satyr_hellcaller_shockwave", {
+    type = "point",
+    allow_neutrals = true,
+})
+
+register_ability("satyr_trickster_purge", {
+    type = "target",
+    allow_neutrals = true,
+    min_interval = 4,
+})
+
+register_ability("satyr_soulstealer_mana_burn", {
+    type = "target",
+    only_heroes = true,
+    min_interval = 4,
+    aliases = {
+        "satyr_mindstealer_mana_burn",
+    },
+})
+
+register_ability("harpy_storm_chain_lightning", {
+    type = "target",
+    allow_neutrals = true,
+    min_interval = 2.5,
+})
+
+register_ability("centaur_khan_war_stomp", {
+    type = "no_target",
+    radius = 325,
+    min_enemies = 1,
+    allow_neutrals = true,
+})
+
+register_ability("polar_furbolg_ursa_warrior_thunder_clap", {
+    type = "no_target",
+    radius = 350,
+    min_enemies = 1,
+    allow_neutrals = true,
+    aliases = {
+        "polar_furbolg_champion_thunder_clap",
+    },
+})
+
+register_ability("hellbear_smasher_slam", {
+    type = "no_target",
+    radius = 350,
+    min_enemies = 1,
+    allow_neutrals = true,
+})
+
+register_ability("ogre_bruiser_ogre_smash", {
+    type = "point",
+    allow_neutrals = true,
+    range_bonus = 60,
+    aliases = {
+        "ogre_mauler_smash",
+    },
+})
+
+register_ability("neutral_ogre_magi_ice_armor", {
+    type = "ally",
+    prefer_hero = true,
+    ally_max_hp = 0.97,
+    avoid_modifier = "modifier_ogre_magi_frost_armor",
+    aliases = {
+        "ogre_magi_frost_armor",
+    },
+})
+
+register_ability("ancient_black_dragon_fireball", {
+    type = "point",
+    allow_neutrals = true,
+    min_interval = 4,
+    aliases = {
+        "black_dragon_fireball",
+    },
+})
+
+register_ability("ancient_thunderhide_slam", {
+    type = "no_target",
+    radius = 325,
+    min_enemies = 1,
+    allow_neutrals = true,
+    aliases = {
+        "big_thunder_lizard_slam",
+    },
+})
+
+register_ability("ancient_thunderhide_frenzy", {
+    type = "ally",
+    prefer_hero = true,
+    include_self = false,
+    min_interval = 6,
+    aliases = {
+        "big_thunder_lizard_frenzy",
+    },
+})
+
+register_ability("fel_beast_haunt", {
+    type = "target",
+    allow_neutrals = true,
+    min_interval = 4,
+})
+
+register_ability("enraged_wildkin_tornado", {
+    type = "point",
+    allow_neutrals = true,
+    min_interval = 12,
+    aliases = {
+        "wildkin_tornado",
+    },
+})
+
+register_ability("wildkin_hurricane", {
+    type = "point",
+    allow_neutrals = true,
+    min_interval = 6,
+})
+
+register_ability("prowler_acolyte_heal", {
+    type = "ally",
+    prefer_hero = true,
+    ally_max_hp = 0.85,
+})
+
+register_ability("kobold_taskmaster_speed_aura", {
+    type = "no_target",
+    always = true,
+    min_interval = 12,
+})
+
+register_ability("neutral_spell_immunity", {
+    type = "no_target",
+    always = true,
+    min_interval = 14,
+})
+
+local function reset_state()
+    state.hero = nil
+    state.team = nil
+    state.player = nil
+    state.player_id = nil
+    state.units = {}
+    state.manual_lock = {}
+    state.last_dominate_attempt = 0
 end
 
-local function EnsureFont()
-    if not runtime.debug_font then
-        runtime.debug_font = Render.LoadFont("Arial", 16, Enum.FontCreate.FONTFLAG_OUTLINE)
+local function current_time()
+    if GlobalVars and GlobalVars.GetCurTime then
+        return GlobalVars.GetCurTime()
     end
-    return runtime.debug_font
+    return os.clock()
 end
 
-local function GetPlayerOwnerID(unit)
-    if NPC and NPC.GetPlayerOwnerID then
-        local ok, owner = pcall(NPC.GetPlayerOwnerID, unit)
-        if ok and type(owner) == "number" and owner >= 0 then
-            return owner
-        end
-    end
-
-    if Entity and Entity.GetPlayerOwnerID then
-        local ok, owner = pcall(Entity.GetPlayerOwnerID, unit)
-        if ok and type(owner) == "number" and owner >= 0 then
-            return owner
-        end
-    end
-
-    return nil
-end
-
-local function GetEntityOwner(unit)
-    if Entity and Entity.GetOwner then
-        local ok, owner = pcall(Entity.GetOwner, unit)
-        if ok and owner and owner ~= unit then
-            return owner
-        end
-    end
-    return nil
-end
-
-local function IsOwnedByHero(unit)
-    if not runtime.hero then
-        return false
-    end
-
-    local current = unit
-    local safety = 0
-    while current and safety < 10 do
-        if current == runtime.hero then
-            return true
-        end
-        current = GetEntityOwner(current)
-        safety = safety + 1
-    end
-
-    return false
-end
-
-local function AcquirePlayerHandle()
-    if IsValidHandle(runtime.player) then
-        return runtime.player
-    end
-
-    runtime.player = nil
-
-    if runtime.player_id then
-        if PlayerResource and PlayerResource.GetPlayer then
-            local ok, candidate = pcall(PlayerResource.GetPlayer, runtime.player_id)
-            if ok and IsValidHandle(candidate) then
-                runtime.player = candidate
-                return runtime.player
-            end
-        end
-
-        if Players and Players.GetPlayer then
-            local ok, candidate = pcall(Players.GetPlayer, runtime.player_id)
-            if ok and IsValidHandle(candidate) then
-                runtime.player = candidate
-                return runtime.player
-            end
-        end
-    end
-
-    if Players and Players.GetLocal then
-        local ok, candidate = pcall(Players.GetLocal)
-        if ok and IsValidHandle(candidate) then
-            runtime.player = candidate
-            if Player and Player.GetPlayerID then
-                local ok_id, pid = pcall(Player.GetPlayerID, candidate)
-                if ok_id and type(pid) == "number" and pid >= 0 then
-                    runtime.player_id = pid
-                end
-            end
-            return runtime.player
-        end
-    end
-
-    return nil
-end
-
-local function UpdateHeroContext()
-    runtime.hero = Heroes and Heroes.GetLocal and Heroes.GetLocal() or nil
-    if not runtime.hero or not Entity.IsAlive(runtime.hero) then
-        ResetRuntime()
-        return false
-    end
-
-    runtime.team = Entity.GetTeamNum(runtime.hero)
-
-    local owner_id = GetPlayerOwnerID(runtime.hero)
-    if not owner_id and Hero and Hero.GetPlayerID then
-        local ok, pid = pcall(Hero.GetPlayerID, runtime.hero)
+local function ensure_player()
+    state.player = Players and Players.GetLocal and Players.GetLocal() or nil
+    if state.player and Player and Player.GetPlayerID then
+        local ok, pid = pcall(Player.GetPlayerID, state.player)
         if ok and type(pid) == "number" and pid >= 0 then
-            owner_id = pid
+            state.player_id = pid
+        end
+    end
+end
+
+local function ensure_hero()
+    if not Heroes or not Heroes.GetLocal then
+        return false
+    end
+
+    local hero = Heroes.GetLocal()
+    if not hero or not Entity.IsAlive(hero) then
+        state.hero = nil
+        return false
+    end
+
+    state.hero = hero
+    state.team = Entity.GetTeamNum(hero)
+
+    if Hero and Hero.GetPlayerID then
+        local ok, pid = pcall(Hero.GetPlayerID, hero)
+        if ok and type(pid) == "number" and pid >= 0 then
+            state.player_id = pid
         end
     end
 
-    runtime.hero_owner_id = owner_id
-
-    if owner_id and owner_id >= 0 then
-        runtime.player_id = runtime.player_id or owner_id
+    if not state.player then
+        ensure_player()
     end
 
-    AcquirePlayerHandle()
     return true
 end
 
--------------------------------------------------------------------------------
--- Menu configuration
--------------------------------------------------------------------------------
-local function EnsureMenu()
-    if runtime.menu_ready then
-        return
+local function is_valid_enemy(unit)
+    if not unit or not Entity.IsAlive(unit) then
+        return false
     end
-
-    if not Menu or not Menu.Create then
-        return
+    if Entity.GetTeamNum(unit) == state.team then
+        return false
     end
-
-    local tab = Menu.Create("Scripts", "Other", "Unit Commander")
-    if not tab then
-        return
+    if NPC.IsCourier and NPC.IsCourier(unit) then
+        return false
     end
-
-    tab:Icon("\u{f0c0}")
-
-    local main_group = tab:Create("Main")
-    local settings = main_group:Create("Settings")
-
-    agent_script.ui.enable = settings:Switch("Включить Unit Commander", true, "\u{f0c0}")
-    agent_script.ui.enable:ToolTip("Автоматически управлять всеми подвластными юнитами, кроме героя и курьера.")
-
-    agent_script.ui.debug = settings:Switch("Показать отладку", true, "\u{f05a}")
-    agent_script.ui.debug:ToolTip("Показывать крупные подписи над юнитами с их текущим состоянием.")
-
-    agent_script.ui.follow_distance = settings:Slider("Дистанция следования", 100, 900, 400, "%d")
-    agent_script.ui.follow_distance:ToolTip("Как далеко юниты могут отходить от героя до начала преследования.")
-
-    agent_script.ui.attack_radius = settings:Slider("Радиус агрессии", 300, 2000, 900, "%d")
-    agent_script.ui.attack_radius:ToolTip("Максимальная дистанция поиска целей для атаки.")
-
-    agent_script.ui.order_cooldown = settings:Slider("Задержка приказов (сек)", 10, 200, 50, "%.1f")
-    agent_script.ui.order_cooldown:ToolTip("Минимальный интервал между приказами (значение делится на 100).")
-
-    agent_script.ui.channel_wait = settings:Slider("Задержка после канала (сек)", 10, 200, 20, "%.1f")
-    agent_script.ui.channel_wait:ToolTip("Ожидание после начала канала способности (значение делится на 100).")
-
-    agent_script.ui.manual_override = settings:Slider("Ручное управление (сек)", 50, 500, 250, "%.1f")
-    agent_script.ui.manual_override:ToolTip("Сколько секунд AI не вмешивается после вашего приказа (значение делится на 100).")
-
-    runtime.menu_ready = true
+    return true
 end
 
-local function ReadConfig()
-    if not runtime.menu_ready then
-        EnsureMenu()
+local function is_valid_friend(unit)
+    if not unit or not Entity.IsAlive(unit) then
+        return false
     end
-
-    runtime.config = runtime.config or {}
-
-    local function slider_value(slider)
-        if not slider then
-            return 0
-        end
-        return (slider:Get() or 0) / 100
+    if Entity.GetTeamNum(unit) ~= state.team then
+        return false
     end
-
-    runtime.config.enabled = agent_script.ui.enable and agent_script.ui.enable:Get() or false
-    runtime.config.debug = agent_script.ui.debug and agent_script.ui.debug:Get() or false
-    runtime.config.follow_distance = (agent_script.ui.follow_distance and agent_script.ui.follow_distance:Get() or 400)
-    runtime.config.attack_radius = (agent_script.ui.attack_radius and agent_script.ui.attack_radius:Get() or 900)
-    runtime.config.order_cooldown = slider_value(agent_script.ui.order_cooldown)
-    runtime.config.channel_wait = slider_value(agent_script.ui.channel_wait)
-    runtime.config.manual_override = slider_value(agent_script.ui.manual_override)
-
-    if runtime.config.order_cooldown < 0.05 then
-        runtime.config.order_cooldown = 0.05
+    if NPC.IsCourier and NPC.IsCourier(unit) then
+        return false
     end
-    if runtime.config.channel_wait < 0.05 then
-        runtime.config.channel_wait = 0.05
-    end
-    if runtime.config.manual_override < 0.1 then
-        runtime.config.manual_override = 0.1
-    end
+    return true
 end
 
--------------------------------------------------------------------------------
--- Ability metadata
--------------------------------------------------------------------------------
-local ABILITY_DATA = {
-    mud_golem_hurl_boulder = {
-        behavior = "target",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Бросаю валун",
-        aliases = {
-            "ancient_rock_golem_hurl_boulder",
-            "granite_golem_hurl_boulder",
-        },
-    },
-    dark_troll_warlord_ensnare = {
-        behavior = "target",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Бросаю сеть",
-    },
-    dark_troll_warlord_raise_dead = {
-        behavior = "no_target",
-        always_cast = true,
-        ignore_is_castable = true,
-        message = "Призываю скелетов",
-        aliases = {
-            "dark_troll_summoner_raise_dead",
-            "dark_troll_warlord_raise_dead_datadriven",
-        },
-    },
-    forest_troll_high_priest_heal = {
-        behavior = "ally_target",
-        prefer_anchor = true,
-        prefer_ally_hero = true,
-        ally_max_health_pct = 0.92,
-        message = "Лечу союзника",
-    },
-    satyr_hellcaller_shockwave = {
-        behavior = "point",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Шоковая волна",
-    },
-    satyr_trickster_purge = {
-        behavior = "target",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Снимаю эффекты",
-    },
-    satyr_soulstealer_mana_burn = {
-        behavior = "target",
-        only_heroes = true,
-        min_mana = 75,
-        message = "Выжигаю ману",
-        aliases = {
-            "satyr_mindstealer_mana_burn",
-        },
-    },
-    harpy_storm_chain_lightning = {
-        behavior = "target",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Цепная молния",
-    },
-    centaur_khan_war_stomp = {
-        behavior = "no_target",
-        radius = 315,
-        min_enemies = 1,
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Оглушаю врагов",
-    },
-    polar_furbolg_ursa_warrior_thunder_clap = {
-        behavior = "no_target",
-        radius = 315,
-        min_enemies = 1,
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Громовой удар",
-        aliases = {
-            "polar_furbolg_champion_thunder_clap",
-        },
-    },
-    hellbear_smasher_slam = {
-        behavior = "no_target",
-        radius = 350,
-        min_enemies = 1,
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Мощный удар",
-    },
-    ogre_bruiser_ogre_smash = {
-        behavior = "point",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Размазываю врага",
-        range_bonus = 50,
-        aliases = {
-            "ogre_mauler_smash",
-        },
-    },
-    neutral_ogre_magi_ice_armor = {
-        behavior = "ally_target",
-        prefer_anchor = true,
-        prefer_ally_hero = true,
-        avoid_modifier = "modifier_ogre_magi_frost_armor",
-        message = "Накладываю броню",
-        aliases = {
-            "ogre_magi_frost_armor",
-        },
-    },
-    ancient_black_dragon_fireball = {
-        behavior = "point",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Огненный шар",
-        aliases = {
-            "black_dragon_fireball",
-        },
-    },
-    ancient_thunderhide_slam = {
-        behavior = "no_target",
-        radius = 315,
-        min_enemies = 1,
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Громовой топот",
-        aliases = {
-            "big_thunder_lizard_slam",
-        },
-    },
-    ancient_thunderhide_frenzy = {
-        behavior = "ally_target",
-        prefer_anchor = true,
-        include_self = false,
-        message = "Бешенство",
-        aliases = {
-            "big_thunder_lizard_frenzy",
-        },
-    },
-    fel_beast_haunt = {
-        behavior = "target",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Пугаю врага",
-    },
-    enraged_wildkin_tornado = {
-        behavior = "point",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Призываю торнадо",
-        aliases = {
-            "wildkin_tornado",
-        },
-    },
-    wildkin_hurricane = {
-        behavior = "point",
-        allow_creeps = true,
-        allow_neutrals = true,
-        message = "Сильный порыв",
-    },
-    prowler_acolyte_heal = {
-        behavior = "ally_target",
-        prefer_ally_hero = true,
-        ally_max_health_pct = 0.85,
-        message = "Лечу союзника",
-    },
-    kobold_taskmaster_speed_aura = {
-        behavior = "no_target",
-        always_cast = true,
-        ignore_is_castable = true,
-        message = "Ускоряю отряд",
-    },
-    neutral_spell_immunity = {
-        behavior = "no_target",
-        always_cast = true,
-        message = "Щит",
-    },
-}
-
-local function ExpandAbilityAliases()
-    local pending = {}
-    for name, metadata in pairs(ABILITY_DATA) do
-        if metadata.aliases then
-            for _, alias in ipairs(metadata.aliases) do
-                if not ABILITY_DATA[alias] then
-                    table.insert(pending, { alias, metadata })
-                end
-            end
-        end
+local function should_control(unit)
+    if not unit or not Entity.IsAlive(unit) then
+        return false
     end
-
-    for _, entry in ipairs(pending) do
-        ABILITY_DATA[entry[1]] = entry[2]
+    if unit == state.hero then
+        return false
     end
-end
-
-ExpandAbilityAliases()
-
--------------------------------------------------------------------------------
--- Ability helpers
--------------------------------------------------------------------------------
-local function GetAbilityCharges(ability)
-    if not ability then
-        return nil
+    if NPC.IsIllusion and NPC.IsIllusion(unit) then
+        return false
     end
-
-    local readers = {
-        "GetCurrentAbilityCharges",
-        "GetCurrentCharges",
-        "GetRemainingCharges",
-        "GetCharges",
-    }
-
-    for _, name in ipairs(readers) do
-        local getter = Ability[name]
-        if type(getter) == "function" then
-            local ok, value = pcall(getter, ability)
-            if ok and type(value) == "number" then
-                return value
-            end
-        end
+    if NPC.IsCourier and NPC.IsCourier(unit) then
+        return false
     end
-
-    return nil
-end
-
-local function IsAbilityReady(unit, ability, metadata)
-    if not ability then
+    if NPC.IsWaitingToSpawn and NPC.IsWaitingToSpawn(unit) then
+        return false
+    end
+    if Entity.GetTeamNum(unit) ~= state.team then
         return false
     end
 
-    if Ability.GetLevel and Ability.GetLevel(ability) <= 0 then
-        return false
-    end
-
-    if Ability.IsHidden and Ability.IsHidden(ability) then
-        return false
-    end
-
-    if Ability.IsPassive and Ability.IsPassive(ability) then
-        return false
-    end
-
-    if Ability.GetCooldownTimeRemaining then
-        local ok, remaining = pcall(Ability.GetCooldownTimeRemaining, ability)
-        if ok and remaining and remaining > 0 then
-            return false
+    if state.player_id and state.player_id >= 0 then
+        if NPC.IsControllableByPlayer and NPC.IsControllableByPlayer(unit, state.player_id) then
+            return true
         end
-    end
-
-    if metadata and metadata.requires_charges then
-        local charges = GetAbilityCharges(ability)
-        if not charges or charges <= 0 then
-            return false
-        end
-    end
-
-    if metadata and metadata.ignore_is_castable then
-        return true
-    end
-
-    if Ability.IsReady then
-        local ok, ready = pcall(Ability.IsReady, ability)
-        if ok and ready then
+        if Entity.IsControllableByPlayer and Entity.IsControllableByPlayer(unit, state.player_id) then
             return true
         end
     end
 
-    if Ability.IsCastable then
-        local ok, castable = pcall(Ability.IsCastable, ability, NPC.GetMana(unit))
-        if ok then
-            return castable
+    if state.hero then
+        local owner = NPC.GetOwnerNPC and NPC.GetOwnerNPC(unit)
+        if owner and owner == state.hero then
+            return true
         end
     end
 
     return false
 end
 
-local function GetAbilityCastRange(unit, ability, metadata)
-    if metadata and metadata.range then
-        return metadata.range
+local function order(unit, order_type, target, position, ability)
+    if not state.player or not Player or not Player.PrepareUnitOrders then
+        return
     end
-
-    if Ability.GetCastRange then
-        local ok, range = pcall(Ability.GetCastRange, ability)
-        if ok and range and range > 0 then
-            return range
-        end
-    end
-
-    if ability and Ability.GetSpecialValueFor then
-        local ok, value = pcall(Ability.GetSpecialValueFor, ability, "cast_range")
-        if ok and value and value > 0 then
-            return value
-        end
-    end
-
-    return 600
-end
-
-local function SafeOrder(unit, order, target, position, ability)
-    local player = AcquirePlayerHandle()
-    if not player then
+    if not Enum or not Enum.UnitOrder or not Enum.PlayerOrderIssuer then
         return
     end
 
     Player.PrepareUnitOrders(
-        player,
-        order,
+        state.player,
+        order_type,
         target,
         position,
         ability,
         Enum.PlayerOrderIssuer.DOTA_ORDER_ISSUER_PASSED_UNIT_ONLY,
-        unit
+        unit,
+        false,
+        false,
+        true
     )
 end
 
-local function SafeCastTarget(unit, ability, target)
-    if Ability.CastTarget then
-        local ok = pcall(Ability.CastTarget, ability, target)
-        if ok then
-            return
-        end
-    end
-    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_TARGET, target, nil, ability)
+local function move_to(unit, position)
+    order(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_MOVE_TO_POSITION, nil, position, nil)
 end
 
-local function SafeCastPosition(unit, ability, position)
-    if Ability.CastPosition then
-        local ok = pcall(Ability.CastPosition, ability, position)
-        if ok then
-            return
-        end
-    end
-    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_POSITION, nil, position, ability)
+local function attack(unit, target)
+    order(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_ATTACK_TARGET, target, nil, nil)
 end
 
-local function SafeCastNoTarget(unit, ability)
-    if Ability.CastNoTarget then
-        local ok = pcall(Ability.CastNoTarget, ability)
-        if ok then
-            return
-        end
+local function cast_target(unit, ability, target)
+    if Ability and Ability.CastTarget then
+        Ability.CastTarget(ability, target)
+    else
+        order(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_TARGET, target, nil, ability)
     end
-    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_NO_TARGET, nil, nil, ability)
 end
 
-local function GetUnitHealthPercent(unit)
-    if not unit or not Entity.IsAlive(unit) then
-        return 0
+local function cast_position(unit, ability, position)
+    if Ability and Ability.CastPosition then
+        Ability.CastPosition(ability, position)
+    else
+        order(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_POSITION, nil, position, ability)
     end
-
-    local health = Entity.GetHealth(unit) or 0
-    local max_health = Entity.GetMaxHealth(unit) or 0
-
-    if max_health <= 0 then
-        return 0
-    end
-
-    return health / max_health
 end
 
-local function EnemyMatches(enemy, metadata)
-    if not enemy or not Entity.IsAlive(enemy) then
+local function cast_no_target(unit, ability)
+    if Ability and Ability.CastNoTarget then
+        Ability.CastNoTarget(ability)
+    else
+        order(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_NO_TARGET, nil, nil, ability)
+    end
+end
+
+local function ability_recently_used(ability, data)
+    if not data or not data.min_interval or not Ability or not Ability.SecondsSinceLastUse then
         return false
     end
-
-    if Entity.GetTeamNum(enemy) == runtime.team then
+    local since = Ability.SecondsSinceLastUse(ability)
+    if not since or since < 0 then
         return false
     end
-
-    if NPC.IsCourier and NPC.IsCourier(enemy) then
-        return false
-    end
-
-    local is_hero = NPC.IsHero(enemy)
-    local is_creep = NPC.IsCreep(enemy) and not is_hero
-    local is_neutral = Entity.GetTeamNum(enemy) == Enum.TeamNum.TEAM_NEUTRAL
-
-    if metadata then
-        if metadata.only_heroes and not is_hero then
-            return false
-        end
-        if is_creep and metadata.allow_creeps == false then
-            return false
-        end
-        if is_neutral and metadata.allow_neutrals == false then
-            return false
-        end
-        if metadata.min_mana and NPC.GetMana(enemy) < metadata.min_mana then
-            return false
-        end
-        if metadata.avoid_modifier and NPC.HasModifier(enemy, metadata.avoid_modifier) then
-            return false
-        end
-    end
-
-    return true
+    return since < data.min_interval
 end
 
-local function AllyMatches(ally, metadata)
-    if not ally or not Entity.IsAlive(ally) then
+local function ability_ready(unit, ability, data)
+    if not ability then
         return false
     end
+    if Ability.GetLevel and Ability.GetLevel(ability) <= 0 then
+        return false
+    end
+    if Ability.IsHidden and Ability.IsHidden(ability) then
+        return false
+    end
+    if Ability.IsPassive and Ability.IsPassive(ability) then
+        return false
+    end
+    if ability_recently_used(ability, data) then
+        return false
+    end
+    if Ability.IsReady then
+        return Ability.IsReady(ability)
+    end
+    if Ability.IsCastable then
+        return Ability.IsCastable(ability, NPC.GetMana(unit))
+    end
+    return false
+end
 
-    if metadata then
-        if metadata.include_self == false and ally == runtime.hero then
-            return false
+local function ability_range(unit, ability, data)
+    if data and data.range then
+        return data.range
+    end
+    if Ability.GetCastRange then
+        local ok, range = pcall(Ability.GetCastRange, ability)
+        if ok and type(range) == "number" and range > 0 then
+            if data and data.range_bonus then
+                range = range + data.range_bonus
+            end
+            return range
         end
-        if metadata.ally_max_health_pct then
-            if GetUnitHealthPercent(ally) >= metadata.ally_max_health_pct then
-                return false
+    end
+    local base = 600
+    if data and data.range_bonus then
+        base = base + data.range_bonus
+    end
+    return base
+end
+
+local function enemies_near(center, radius, include_neutrals)
+    local result = {}
+    if not center then
+        return result
+    end
+
+    local enemies = NPCs and NPCs.InRadius and NPCs.InRadius(center, radius, state.team, Enum.TeamType.TEAM_ENEMY) or {}
+    for _, enemy in ipairs(enemies) do
+        if is_valid_enemy(enemy) then
+            table.insert(result, enemy)
+        end
+    end
+
+    if include_neutrals then
+        local neutrals = NPCs and NPCs.InRadius and NPCs.InRadius(center, radius, state.team, Enum.TeamType.TEAM_NEUTRAL) or {}
+        for _, enemy in ipairs(neutrals) do
+            if is_valid_enemy(enemy) then
+                table.insert(result, enemy)
             end
         end
-        if metadata.ally_min_health_pct then
-            if GetUnitHealthPercent(ally) <= metadata.ally_min_health_pct then
-                return false
-            end
-        end
-        if metadata.avoid_modifier and NPC.HasModifier(ally, metadata.avoid_modifier) then
-            return false
-        end
     end
 
-    return true
+    return result
 end
 
-local function FindEnemyTarget(unit, metadata, cast_range, current_target, anchor_pos)
+local function select_enemy(unit, data, range, hero_pos)
     local unit_pos = Entity.GetAbsOrigin(unit)
-    local centers = {}
-
+    local anchors = {}
     if unit_pos then
-        centers[#centers + 1] = unit_pos
+        table.insert(anchors, unit_pos)
     end
-    if anchor_pos then
-        centers[#centers + 1] = anchor_pos
+    if hero_pos then
+        table.insert(anchors, hero_pos)
     end
 
     local best_target
     local best_score = -math.huge
 
-    if current_target and EnemyMatches(current_target, metadata) then
-        local pos = Entity.GetAbsOrigin(current_target)
-        if pos and unit_pos and unit_pos:Distance(pos) <= cast_range + (metadata and metadata.range_bonus or 0) then
-            best_target = current_target
-            best_score = 1000
-        end
-    end
-
-    for _, center in ipairs(centers) do
-        local enemies = NPCs.InRadius(center, cast_range + (metadata and metadata.range_bonus or 0), runtime.team, Enum.TeamType.TEAM_ENEMY) or {}
-        for _, enemy in ipairs(enemies) do
-            if EnemyMatches(enemy, metadata) then
-                local pos = Entity.GetAbsOrigin(enemy)
-                if pos then
-                    local distance = center:Distance(pos)
-                    if distance <= cast_range + (metadata and metadata.range_bonus or 0) then
-                        local score = -distance
-                        if NPC.IsHero(enemy) then
-                            score = score + 300
+    for _, anchor in ipairs(anchors) do
+        local targets = enemies_near(anchor, range, data and data.allow_neutrals)
+        for _, enemy in ipairs(targets) do
+            if not data or not data.only_heroes or NPC.IsHero(enemy) then
+                local enemy_pos = Entity.GetAbsOrigin(enemy)
+                if enemy_pos then
+                    local distance = unit_pos and unit_pos:Distance(enemy_pos) or anchor:Distance(enemy_pos)
+                    if distance <= range + 50 then
+                        local score = 0
+                        if NPC.IsHero and NPC.IsHero(enemy) then
+                            score = score + 400
                         end
-
-                        local idx = Entity.GetIndex(enemy)
-                        if runtime.threat_expiry[idx] and runtime.threat_expiry[idx] > GlobalVars.GetCurTime() then
-                            score = score + 150
+                        if NPC.IsTower and NPC.IsTower(enemy) then
+                            score = score + 120
                         end
-
+                        score = score - distance * 0.5
                         if score > best_score then
                             best_score = score
                             best_target = enemy
@@ -744,19 +520,281 @@ local function FindEnemyTarget(unit, metadata, cast_range, current_target, ancho
                 end
             end
         end
+    end
 
-        if metadata and metadata.allow_neutrals ~= false then
-            local neutrals = NPCs.InRadius(center, cast_range + (metadata and metadata.range_bonus or 0), runtime.team, Enum.TeamType.TEAM_NEUTRAL) or {}
-            for _, enemy in ipairs(neutrals) do
-                if EnemyMatches(enemy, metadata) then
-                    local pos = Entity.GetAbsOrigin(enemy)
-                    if pos then
-                        local distance = center:Distance(pos)
-                        if distance <= cast_range + (metadata and metadata.range_bonus or 0) then
-                            local score = -distance
+    return best_target
+end
+
+local function select_ally(unit, data, range, hero)
+    local unit_pos = Entity.GetAbsOrigin(unit)
+    if not unit_pos then
+        return nil
+    end
+
+    local best
+    local best_score = -math.huge
+
+    local function consider(candidate)
+        if not is_valid_friend(candidate) then
+            return
+        end
+        if candidate == unit and data and data.include_self == false then
+            return
+        end
+        if data and data.only_heroes and (not NPC.IsHero(candidate)) then
+            return
+        end
+        local pos = Entity.GetAbsOrigin(candidate)
+        if not pos or unit_pos:Distance(pos) > range then
+            return
+        end
+        if data and data.avoid_modifier and NPC.HasModifier and NPC.HasModifier(candidate, data.avoid_modifier) then
+            return
+        end
+        local hp = Entity.GetHealth(candidate)
+        local max_hp = Entity.GetMaxHealth(candidate)
+        local hp_pct = 1
+        if hp and max_hp and max_hp > 0 then
+            hp_pct = hp / max_hp
+        end
+        if data and data.ally_max_hp and hp_pct > data.ally_max_hp then
+            return
+        end
+        if data and data.ally_min_hp and hp_pct < data.ally_min_hp then
+            return
+        end
+        local score = -hp_pct * 100
+        if NPC.IsHero and NPC.IsHero(candidate) then
+            score = score + 200
+        end
+        if hero and candidate == hero then
+            score = score + 150
+        end
+        if data and data.prefer_hero and hero and candidate == hero then
+            score = score + 200
+        end
+        if score > best_score then
+            best_score = score
+            best = candidate
+        end
+    end
+
+    if data and data.prefer_hero and hero then
+        consider(hero)
+    end
+
+    local allies = NPCs and NPCs.InRadius and NPCs.InRadius(unit_pos, range, state.team, Enum.TeamType.TEAM_FRIEND) or {}
+    for _, ally in ipairs(allies) do
+        consider(ally)
+    end
+
+    return best
+end
+
+local function should_cast_no_target(unit, ability, data)
+    if data and data.always then
+        return true
+    end
+
+    local radius = data and data.radius or (Ability and Ability.GetAOERadius and Ability.GetAOERadius(ability)) or 275
+    local unit_pos = Entity.GetAbsOrigin(unit)
+    if not unit_pos then
+        return false
+    end
+
+    local targets = enemies_near(unit_pos, radius, data and data.allow_neutrals)
+    local required = 1
+    if data and data.min_enemies then
+        required = data.min_enemies
+    end
+
+    return #targets >= required
+end
+
+local function try_cast(unit, info, ability, data, now, hero_pos)
+    if not ability_ready(unit, ability, data) then
+        return false
+    end
+
+    local ability_type = data and data.type
+    if ability_type == "target" then
+        local range = ability_range(unit, ability, data)
+        local target = select_enemy(unit, data, range, hero_pos)
+        if target then
+            cast_target(unit, ability, target)
+            info.next_action = now + CAST_COOLDOWN
+            info.current_target = target
+            return true
+        end
+    elseif ability_type == "point" then
+        local range = ability_range(unit, ability, data)
+        local target = select_enemy(unit, data, range, hero_pos)
+        local position = target and Entity.GetAbsOrigin(target)
+        if position then
+            cast_position(unit, ability, position)
+            info.next_action = now + CAST_COOLDOWN
+            info.current_target = target
+            return true
+        end
+    elseif ability_type == "ally" then
+        local range = ability_range(unit, ability, data)
+        local ally = select_ally(unit, data, range, state.hero)
+        if ally then
+            cast_target(unit, ability, ally)
+            info.next_action = now + CAST_COOLDOWN
+            return true
+        end
+    elseif ability_type == "no_target" then
+        if should_cast_no_target(unit, ability, data) then
+            cast_no_target(unit, ability)
+            info.next_action = now + CAST_COOLDOWN
+            return true
+        end
+    end
+
+    return false
+end
+
+local function process_abilities(unit, info, now, hero_pos)
+    if NPC.IsSilenced and NPC.IsSilenced(unit) then
+        return false
+    end
+    if NPC.IsStunned and NPC.IsStunned(unit) then
+        return false
+    end
+    if NPC.IsChannellingAbility and NPC.IsChannellingAbility(unit) then
+        return false
+    end
+
+    for slot = 0, 23 do
+        local ability = NPC.GetAbilityByIndex and NPC.GetAbilityByIndex(unit, slot)
+        if not ability then
+            break
+        end
+        local name = Ability and Ability.GetName and Ability.GetName(ability)
+        if name then
+            local data = ability_data[name]
+            if data and try_cast(unit, info, ability, data, now, hero_pos) then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+local function select_attack_target(unit, info, hero_pos)
+    local unit_pos = Entity.GetAbsOrigin(unit)
+    local best
+    local best_score = -math.huge
+    local centers = {}
+
+    if unit_pos then
+        table.insert(centers, unit_pos)
+    end
+    if hero_pos then
+        table.insert(centers, hero_pos)
+    end
+
+    for _, center in ipairs(centers) do
+        local enemies = enemies_near(center, ATTACK_RADIUS, true)
+        for _, enemy in ipairs(enemies) do
+            local enemy_pos = Entity.GetAbsOrigin(enemy)
+            if enemy_pos then
+                local distance = unit_pos and unit_pos:Distance(enemy_pos) or center:Distance(enemy_pos)
+                local score = -distance
+                if NPC.IsHero and NPC.IsHero(enemy) then
+                    score = score + 400
+                end
+                if info.current_target and enemy == info.current_target then
+                    score = score + 80
+                end
+                if score > best_score then
+                    best_score = score
+                    best = enemy
+                end
+            end
+        end
+    end
+
+    return best
+end
+
+local function process_unit(unit, info, now, hero_pos)
+    local handle = Entity.GetIndex(unit)
+    local lock = state.manual_lock[handle]
+    if lock and lock > now then
+        return
+    end
+
+    if info.next_action and info.next_action > now then
+        return
+    end
+
+    if process_abilities(unit, info, now, hero_pos) then
+        return
+    end
+
+    if info.current_target and (not Entity.IsAlive(info.current_target) or Entity.GetTeamNum(info.current_target) == state.team) then
+        info.current_target = nil
+    end
+
+    local target = select_attack_target(unit, info, hero_pos)
+    if target then
+        if info.current_target ~= target then
+            attack(unit, target)
+            info.current_target = target
+            info.next_action = now + ORDER_COOLDOWN
+        end
+        return
+    end
+
+    if not hero_pos then
+        return
+    end
+
+    local unit_pos = Entity.GetAbsOrigin(unit)
+    if not unit_pos then
+        return
+    end
+
+    local distance = unit_pos:Distance(hero_pos)
+    if distance > FOLLOW_DISTANCE then
+        move_to(unit, hero_pos)
+        info.next_action = now + ORDER_COOLDOWN
+    end
+end
+
+local function dominator_target(hero, item)
+    if not hero or not item then
+        return nil
+    end
+    local hero_pos = Entity.GetAbsOrigin(hero)
+    if not hero_pos then
+        return nil
+    end
+
+    local range = ability_range(hero, item, { range_bonus = 0 })
+    if range < 700 then
+        range = 700
+    end
+    local units = NPCs and NPCs.InRadius and NPCs.InRadius(hero_pos, range + 50, state.team, Enum.TeamType.TEAM_NEUTRAL) or {}
+    local best
+    local best_score = -math.huge
+    local allow_ancients = Ability and Ability.GetName and Ability.GetName(item) == "item_helm_of_the_overlord"
+
+    for _, neutral in ipairs(units) do
+        if Entity.IsAlive(neutral) and (not NPC.IsWaitingToSpawn or not NPC.IsWaitingToSpawn(neutral)) then
+            local name = Entity.GetUnitName(neutral)
+            local score = DOMINATOR_PRIORITY[name]
+            if score then
+                local is_ancient = ANCIENT_NEUTRALS[name] or false
+                if not is_ancient or allow_ancients then
+                    if not NPC.HasModifier or not NPC.HasModifier(neutral, "modifier_helm_of_the_dominator") then
+                        if not NPC.HasModifier or not NPC.HasModifier(neutral, "modifier_helm_of_the_overlord") then
                             if score > best_score then
+                                best = neutral
                                 best_score = score
-                                best_target = enemy
                             end
                         end
                     end
@@ -765,493 +803,116 @@ local function FindEnemyTarget(unit, metadata, cast_range, current_target, ancho
         end
     end
 
-    return best_target
+    return best
 end
 
-local function ChooseAllyTarget(unit, metadata, cast_range, anchor_unit, anchor_pos)
-    if metadata and metadata.prefer_anchor and anchor_unit and AllyMatches(anchor_unit, metadata) then
-        local anchor_position = anchor_pos or Entity.GetAbsOrigin(anchor_unit)
-        local unit_pos = Entity.GetAbsOrigin(unit)
-        if anchor_position and unit_pos and unit_pos:Distance(anchor_position) <= cast_range + (metadata and metadata.range_bonus or 0) then
-            return anchor_unit
-        end
-    end
-
-    if metadata and metadata.prefer_ally_hero and runtime.hero and AllyMatches(runtime.hero, metadata) then
-        local hero_pos = Entity.GetAbsOrigin(runtime.hero)
-        local unit_pos = Entity.GetAbsOrigin(unit)
-        if hero_pos and unit_pos and unit_pos:Distance(hero_pos) <= cast_range + (metadata and metadata.range_bonus or 0) then
-            return runtime.hero
-        end
-    end
-
-    local unit_pos = Entity.GetAbsOrigin(unit)
-    if not unit_pos then
-        return nil
-    end
-
-    local best_target
-    local best_score = -math.huge
-
-    local friends = NPCs.InRadius(unit_pos, cast_range + (metadata and metadata.range_bonus or 0), runtime.team, Enum.TeamType.TEAM_FRIEND) or {}
-    for _, ally in ipairs(friends) do
-        if AllyMatches(ally, metadata) then
-            local pos = Entity.GetAbsOrigin(ally)
-            if pos then
-                local distance = unit_pos:Distance(pos)
-                if distance <= cast_range + (metadata and metadata.range_bonus or 0) then
-                    local score = -distance
-                    if NPC.IsHero(ally) then
-                        score = score + 120
-                    end
-                    if score > best_score then
-                        best_score = score
-                        best_target = ally
-                    end
-                end
-            end
-        end
-    end
-
-    return best_target
-end
-
-local function ShouldCastNoTargetAbility(unit, metadata, ability)
-    if metadata and metadata.always_cast then
-        return true
-    end
-
-    local radius = metadata and metadata.radius
-    if not radius and Ability.GetAOERadius then
-        local ok, value = pcall(Ability.GetAOERadius, ability)
-        if ok and value and value > 0 then
-            radius = value
-        end
-    end
-    radius = radius or 250
-
-    local unit_pos = Entity.GetAbsOrigin(unit)
-    if not unit_pos then
-        return false
-    end
-
-    local enemies = NPCs.InRadius(unit_pos, radius, runtime.team, Enum.TeamType.TEAM_ENEMY) or {}
-    local neutrals = NPCs.InRadius(unit_pos, radius, runtime.team, Enum.TeamType.TEAM_NEUTRAL) or {}
-
-    local total = 0
-    for _, enemy in ipairs(enemies) do
-        if EnemyMatches(enemy, metadata) then
-            total = total + 1
-        end
-    end
-
-    if metadata and metadata.allow_neutrals ~= false then
-        for _, enemy in ipairs(neutrals) do
-            if EnemyMatches(enemy, metadata) then
-                total = total + 1
-            end
-        end
-    end
-
-    local minimum = 1
-    if metadata and metadata.min_enemies then
-        minimum = metadata.min_enemies
-    end
-
-    return total >= minimum
-end
-
-local function TryCastAbility(unit, agent, now, ability, metadata, current_target, anchor_unit, anchor_pos)
-    if not IsAbilityReady(unit, ability, metadata) then
-        return false
-    end
-
-    local behavior = metadata and metadata.behavior
-    local cast_range = GetAbilityCastRange(unit, ability, metadata)
-
-    if behavior == "target" then
-        local enemy = FindEnemyTarget(unit, metadata, cast_range, current_target, anchor_pos)
-        if enemy then
-            SafeCastTarget(unit, ability, enemy)
-            agent.last_action = metadata and metadata.message or "Использую способность"
-            agent.next_order_time = now + runtime.config.order_cooldown
-            return true
-        end
-    elseif behavior == "point" then
-        local enemy = FindEnemyTarget(unit, metadata, cast_range, current_target, anchor_pos)
-        local cast_pos = enemy and Entity.GetAbsOrigin(enemy)
-        if not cast_pos and metadata and metadata.always_cast then
-            cast_pos = Entity.GetAbsOrigin(unit)
-        end
-        if cast_pos then
-            SafeCastPosition(unit, ability, cast_pos)
-            agent.last_action = metadata and metadata.message or "Использую способность"
-            agent.next_order_time = now + runtime.config.order_cooldown
-            return true
-        end
-    elseif behavior == "no_target" then
-        if ShouldCastNoTargetAbility(unit, metadata, ability) then
-            SafeCastNoTarget(unit, ability)
-            agent.last_action = metadata and metadata.message or "Использую способность"
-            agent.next_order_time = now + runtime.config.order_cooldown
-            return true
-        end
-    elseif behavior == "ally_target" then
-        local ally = ChooseAllyTarget(unit, metadata, cast_range, anchor_unit, anchor_pos)
-        if ally then
-            SafeCastTarget(unit, ability, ally)
-            agent.last_action = metadata and metadata.message or "Поддерживаю союзника"
-            agent.next_order_time = now + runtime.config.order_cooldown
-            return true
-        end
-    end
-
-    return false
-end
-
-local function TryCastAbilities(unit, agent, now, current_target, anchor_unit, anchor_pos)
-    if NPC.IsChannellingAbility and NPC.IsChannellingAbility(unit) then
-        agent.state = STATES.ENGAGE
-        agent.last_action = "Канализирую"
-        agent.next_order_time = now + runtime.config.channel_wait
-        return true
-    end
-
-    for slot = 0, 23 do
-        local ability = NPC.GetAbilityByIndex(unit, slot)
-        if ability then
-            local name = Ability.GetName(ability)
-            local metadata = ABILITY_DATA[name]
-            if metadata then
-                if TryCastAbility(unit, agent, now, ability, metadata, current_target, anchor_unit, anchor_pos) then
-                    return true
-                end
-            end
-        end
-    end
-
-    return false
-end
-
--------------------------------------------------------------------------------
--- Agent management
--------------------------------------------------------------------------------
-local function CreateAgent(unit)
-    return {
-        unit = unit,
-        handle = Entity.GetIndex(unit),
-        state = STATES.FOLLOW,
-        last_action = "Инициализация",
-        next_order_time = 0,
-        manual_until = 0,
-        current_target = nil,
-    }
-end
-
-local function MoveToPosition(unit, position, agent, now)
-    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_MOVE_TO_POSITION, nil, position, nil)
-    agent.state = STATES.FOLLOW
-    agent.last_action = "Следую к герою"
-    agent.next_order_time = now + runtime.config.order_cooldown
-end
-
-local function HoldPosition(unit, agent, now)
-    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_HOLD_POSITION, nil, Entity.GetAbsOrigin(unit), nil)
-    agent.state = STATES.FOLLOW
-    agent.last_action = "Ожидаю"
-    agent.next_order_time = now + runtime.config.order_cooldown
-end
-
-local function AttackTarget(unit, target, agent, now)
-    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_ATTACK_TARGET, target, nil, nil)
-    agent.state = STATES.ENGAGE
-    local target_name = NPC.GetUnitName(target) or "цель"
-    agent.last_action = string.format("Атакую %s", target_name)
-    agent.current_target = target
-    agent.next_order_time = now + runtime.config.order_cooldown
-end
-
-local function AcquireAttackTarget(unit, anchor_pos)
-    local radius = runtime.config.attack_radius or 900
-    local unit_pos = Entity.GetAbsOrigin(unit)
-    local centers = {}
-    if unit_pos then
-        centers[#centers + 1] = unit_pos
-    end
-    if anchor_pos then
-        centers[#centers + 1] = anchor_pos
-    end
-
-    local best_target
-    local best_score = -math.huge
-
-    for _, center in ipairs(centers) do
-        local enemies = NPCs.InRadius(center, radius, runtime.team, Enum.TeamType.TEAM_ENEMY) or {}
-        for _, enemy in ipairs(enemies) do
-            if Entity.IsAlive(enemy) and Entity.GetTeamNum(enemy) ~= runtime.team and (not NPC.IsCourier(enemy)) then
-                local pos = Entity.GetAbsOrigin(enemy)
-                if pos then
-                    local distance = center:Distance(pos)
-                    local score = -distance
-                    if NPC.IsHero(enemy) then
-                        score = score + 400
-                    end
-                    local idx = Entity.GetIndex(enemy)
-                    if runtime.threat_expiry[idx] and runtime.threat_expiry[idx] > GlobalVars.GetCurTime() then
-                        score = score + 200
-                    end
-                    if score > best_score then
-                        best_score = score
-                        best_target = enemy
-                    end
-                end
-            end
-        end
-
-        local neutrals = NPCs.InRadius(center, radius, runtime.team, Enum.TeamType.TEAM_NEUTRAL) or {}
-        for _, enemy in ipairs(neutrals) do
-            if Entity.IsAlive(enemy) then
-                local pos = Entity.GetAbsOrigin(enemy)
-                if pos then
-                    local distance = center:Distance(pos)
-                    local score = -distance
-                    if score > best_score then
-                        best_score = score
-                        best_target = enemy
-                    end
-                end
-            end
-        end
-    end
-
-    return best_target
-end
-
-local function ProcessAgent(agent, now)
-    local unit = agent.unit
-    if not unit or not Entity.IsAlive(unit) then
+local function auto_dominate(now)
+    if not state.hero then
         return
     end
 
-    local manual_remaining = agent.manual_until - now
-    if manual_remaining > 0 then
-        agent.state = STATES.MANUAL
-        agent.last_action = string.format("Ручное управление (%.1f)", manual_remaining)
+    if now < state.last_dominate_attempt + 0.35 then
         return
     end
 
-    if now < agent.next_order_time then
+    local item
+    for _, name in ipairs(DOMINATOR_ITEMS) do
+        item = NPC.GetItem and NPC.GetItem(state.hero, name, true)
+        if item and ability_ready(state.hero, item, nil) then
+            break
+        end
+        item = nil
+    end
+
+    if not item then
         return
     end
 
-    local anchor_unit = runtime.hero
-    local anchor_pos = anchor_unit and Entity.GetAbsOrigin(anchor_unit)
-    local current_target = agent.current_target
-
-    if TryCastAbilities(unit, agent, now, current_target, anchor_unit, anchor_pos) then
-        return
-    end
-
-    if agent.current_target and (not Entity.IsAlive(agent.current_target) or Entity.GetTeamNum(agent.current_target) == runtime.team) then
-        agent.current_target = nil
-    end
-
-    local target = AcquireAttackTarget(unit, anchor_pos)
+    local target = dominator_target(state.hero, item)
     if target then
-        AttackTarget(unit, target, agent, now)
-        return
-    end
-
-    if anchor_pos then
-        local unit_pos = Entity.GetAbsOrigin(unit)
-        if unit_pos then
-            local distance = unit_pos:Distance(anchor_pos)
-            if distance > runtime.config.follow_distance then
-                MoveToPosition(unit, anchor_pos, agent, now)
-                return
-            end
-        end
-        HoldPosition(unit, agent, now)
+        cast_target(state.hero, item, target)
+        state.last_dominate_attempt = now
     else
-        HoldPosition(unit, agent, now)
+        state.last_dominate_attempt = now
     end
 end
 
--------------------------------------------------------------------------------
--- Unit filtering
--------------------------------------------------------------------------------
-local function ShouldManageUnit(unit)
-    if not unit or not Entity.IsAlive(unit) then
-        return false
-    end
-
-    if unit == runtime.hero then
-        return false
-    end
-
-    if NPC.IsCourier and NPC.IsCourier(unit) then
-        return false
-    end
-
-    if Entity.GetTeamNum(unit) ~= runtime.team then
-        return false
-    end
-
-    if runtime.player_id and NPC.IsControllableByPlayer and NPC.IsControllableByPlayer(unit, runtime.player_id) then
-        return true
-    end
-
-    local owner_id = GetPlayerOwnerID(unit)
-    if owner_id and runtime.player_id and owner_id == runtime.player_id then
-        return true
-    end
-    if owner_id and runtime.hero_owner_id and owner_id == runtime.hero_owner_id then
-        return true
-    end
-
-    if IsOwnedByHero(unit) then
-        return true
-    end
-
-    return false
-end
-
--------------------------------------------------------------------------------
--- Callbacks
--------------------------------------------------------------------------------
-function agent_script.OnUpdate()
-    if not Engine.IsInGame() then
-        ResetRuntime()
+function commander.OnUpdate()
+    if not Engine or not Engine.IsInGame or not Engine.IsInGame() then
+        reset_state()
         return
     end
 
-    EnsureMenu()
-    ReadConfig()
-
-    if not runtime.config.enabled then
-        runtime.agents = {}
+    if not ensure_hero() then
         return
     end
 
-    if not UpdateHeroContext() then
-        return
-    end
+    ensure_player()
 
-    local player = AcquirePlayerHandle()
-    if not player then
-        runtime.agents = {}
-        return
-    end
+    local now = current_time()
+    auto_dominate(now)
 
-    local now = GlobalVars.GetCurTime()
-    local next_agents = {}
+    local hero_pos = state.hero and Entity.GetAbsOrigin(state.hero) or nil
+    local tracked = {}
 
-    for _, unit in ipairs(NPCs.GetAll()) do
-        if ShouldManageUnit(unit) then
+    for _, unit in ipairs(NPCs and NPCs.GetAll and NPCs.GetAll() or {}) do
+        if should_control(unit) then
             local handle = Entity.GetIndex(unit)
-            local agent = runtime.agents[handle]
-            if not agent then
-                agent = CreateAgent(unit)
+            local info = state.units[handle]
+            if not info then
+                info = {
+                    unit = unit,
+                    current_target = nil,
+                    next_action = 0,
+                }
             end
-            agent.unit = unit
-            agent.handle = handle
-            ProcessAgent(agent, now)
-            next_agents[handle] = agent
+            info.unit = unit
+            tracked[handle] = info
+            process_unit(unit, info, now, hero_pos)
         end
     end
 
-    runtime.agents = next_agents
+    state.units = tracked
+
+    for handle, expiry in pairs(state.manual_lock) do
+        if expiry <= now then
+            state.manual_lock[handle] = nil
+        end
+    end
 end
 
-function agent_script.OnDraw()
-    if not runtime.config or not runtime.config.debug then
-        return
+function commander.OnPrepareUnitOrders(data)
+    if not data or not data.npc then
+        return true
+    end
+    if not Engine or not Engine.IsInGame or not Engine.IsInGame() then
+        return true
+    end
+    if not Entity or not Entity.GetIndex then
+        return true
     end
 
-    local font = EnsureFont()
-    for _, agent in pairs(runtime.agents) do
-        local unit = agent.unit
-        if unit and Entity.IsAlive(unit) then
-            local origin = Entity.GetAbsOrigin(unit)
-            local offset = NPC.GetHealthBarOffset(unit) or 0
-            if origin then
-                local screen_pos, visible = Render.WorldToScreen(origin + Vector(0, 0, offset + 32))
-                if visible then
-                    local line1 = string.format("[%s]", agent.state or "?")
-                    local line2 = agent.last_action or ""
-                    local color = Color(180, 220, 255, 255)
-                    if agent.state == STATES.MANUAL then
-                        color = Color(255, 165, 0, 255)
-                    elseif agent.state == STATES.ENGAGE then
-                        color = Color(255, 90, 90, 255)
-                    end
-                    local size1 = Render.TextSize(font, 16, line1)
-                    Render.Text(font, 16, line1, Vec2(screen_pos.x - size1.x / 2, screen_pos.y), color)
-                    local size2 = Render.TextSize(font, 14, line2)
-                    Render.Text(font, 14, line2, Vec2(screen_pos.x - size2.x / 2, screen_pos.y + 18), Color(240, 240, 240, 255))
+    local now = current_time()
+    local handle = Entity.GetIndex(data.npc)
+    state.manual_lock[handle] = now + MANUAL_SUPPRESSION
+
+    if data.issuerNpc then
+        if type(data.issuerNpc) == "table" then
+            for _, unit in ipairs(data.issuerNpc) do
+                if unit then
+                    state.manual_lock[Entity.GetIndex(unit)] = now + MANUAL_SUPPRESSION
                 end
             end
-        end
-    end
-end
-
-local function FlagManualControl(unit)
-    if not unit then
-        return
-    end
-    local handle = Entity.GetIndex(unit)
-    local agent = runtime.agents[handle]
-    if agent then
-        agent.manual_until = GlobalVars.GetCurTime() + runtime.config.manual_override
-        agent.state = STATES.MANUAL
-        agent.last_action = "Ручное управление"
-    end
-end
-
-function agent_script.OnPrepareUnitOrders(data)
-    if not runtime.config or not runtime.config.enabled then
-        return true
-    end
-
-    local player = data.player or AcquirePlayerHandle()
-    if not player then
-        return true
-    end
-
-    if data.orderIssuer == Enum.PlayerOrderIssuer.DOTA_ORDER_ISSUER_PASSED_UNIT_ONLY then
-        if data.npc then
-            FlagManualControl(data.npc)
-        end
-        return true
-    end
-
-    local selected = Player.GetSelectedUnits and Player.GetSelectedUnits(player)
-    if selected then
-        for _, unit in ipairs(selected) do
-            FlagManualControl(unit)
+        else
+            state.manual_lock[Entity.GetIndex(data.issuerNpc)] = now + MANUAL_SUPPRESSION
         end
     end
 
     return true
 end
 
-function agent_script.OnEntityHurt(data)
-    if not runtime.config or not runtime.config.enabled then
-        return
-    end
-
-    if not data or not data.target or not data.source then
-        return
-    end
-
-    if runtime.hero and data.target == runtime.hero then
-        local idx = Entity.GetIndex(data.source)
-        runtime.threat_expiry[idx] = GlobalVars.GetCurTime() + 3
-    end
+function commander.OnGameEnd()
+    reset_state()
 end
 
-function agent_script.OnGameEnd()
-    ResetRuntime()
-end
-
-return agent_script
+return commander

--- a/script.lua
+++ b/script.lua
@@ -44,14 +44,18 @@ local ABILITY_RULES = {
     centaur_khan_war_stomp = { cast = "no_target", range = 325 },
     hellbear_smasher_thunder_clap = { cast = "no_target", range = 350 },
     polar_furbolg_ursa_warrior_thunder_clap = { cast = "no_target", range = 350 },
-    dark_troll_warlord_ensnare = { cast = "target", range = 550, allow_zero_damage = true },
+    dark_troll_warlord_ensnare = { cast = "target", range = 550 },
     satyr_hellcaller_shockwave = { cast = "point", range = 950 },
+    satyr_soulstealer_mana_burn = { cast = "target", range = 650 },
+    satyr_trickster_purge = { cast = "target", range = 350 },
     mudgolem_hurl_boulder = { cast = "target", range = 800 },
     rock_golem_hurl_boulder = { cast = "target", range = 800 },
     greater_mudgolem_hurl_boulder = { cast = "target", range = 800 },
     greater_rock_golem_hurl_boulder = { cast = "target", range = 800 },
+    big_thunder_lizard_slam = { cast = "no_target", range = 325 },
     warpine_raider_seed_shot = { cast = "target", range = 600 },
     ogre_bruiser_ogre_smash = { cast = "point", range = 275 },
+    harpy_storm_chain_lightning = { cast = "target", range = 650 },
     black_dragon_fireball = { cast = "point", range = 1200 },
     ancient_black_dragon_fireball = { cast = "point", range = 1200 },
     granite_golem_hurl_boulder = { cast = "target", range = 900 },
@@ -64,6 +68,7 @@ local NO_TARGET_WHITELIST = {
     hellbear_smasher_thunder_clap = true,
     polar_furbolg_ursa_warrior_thunder_clap = true,
     ancient_thunderhide_slam = true,
+    big_thunder_lizard_slam = true,
 }
 
 local ABILITY_BLACKLIST = {
@@ -71,6 +76,8 @@ local ABILITY_BLACKLIST = {
     enraged_wildkin_tornado = true,
     ogre_magi_frost_armor = true,
     ancient_thunderhide_frenzy = true,
+    big_thunder_lizard_frenzy = true,
+    forest_troll_high_priest_heal = true,
 }
 
 local last_cast_time = 0
@@ -365,13 +372,6 @@ local function cast_creep_ability(creep, ability, enemies, game_time)
         and target_team ~= Enum.TargetTeam.DOTA_UNIT_TARGET_TEAM_ENEMY
         and target_team ~= Enum.TargetTeam.DOTA_UNIT_TARGET_TEAM_BOTH then
         return false
-    end
-
-    if cast_type == "target" and (not config or not config.allow_zero_damage) then
-        local damage = Ability.GetDamage(ability)
-        if not damage or damage <= 0 then
-            return false
-        end
     end
 
     if cast_type == "no_target" and not (config or NO_TARGET_WHITELIST[ability_name]) then

--- a/script.lua
+++ b/script.lua
@@ -1,232 +1,765 @@
----@diagnostic disable: undefined-global
+local agent_script = { ui = {} }
 
-local auto_dominator = {}
+--[[
+    Unit Commander (rewrite)
+    ------------------------
+    Controls all allied units except the hero and courier. Provides a
+    configuration menu, enlarged debug overlays, and automatic spell usage for
+    neutral creeps using UCZone API v2 friendly helpers.
+]]
 
-local DOMINATOR_ITEMS = {
-    "item_helm_of_the_dominator",
-    "item_helm_of_the_overlord",
+-------------------------------------------------------------------------------
+-- Runtime state
+-------------------------------------------------------------------------------
+local runtime = {
+    hero = nil,
+    hero_owner_id = nil,
+    team = nil,
+    player = nil,
+    player_id = nil,
+    config = nil,
+    agents = {},
+    threat_expiry = {},
+    menu_ready = false,
+    debug_font = nil,
 }
 
-local BIG_NEUTRAL_NAMES = {
-    npc_dota_neutral_alpha_wolf = true,
-    npc_dota_neutral_centaur_khan = true,
-    npc_dota_neutral_dark_troll_warlord = true,
-    npc_dota_neutral_enraged_wildkin = true,
-    npc_dota_neutral_hellbear_smasher = true,
-    npc_dota_neutral_mud_golem = true,
-    npc_dota_neutral_ogre_bruiser = true,
-    npc_dota_neutral_ogre_magi = true,
-    npc_dota_neutral_polar_furbolg_ursa_warrior = true,
-    npc_dota_neutral_satyr_hellcaller = true,
-    npc_dota_neutral_warpine_raider = true,
+local STATES = {
+    FOLLOW = "FOLLOW",
+    ENGAGE = "ENGAGE",
+    FARM = "FARM",
+    MANUAL = "MANUAL",
 }
 
-local BIG_NEUTRAL_MIN_HEALTH = 700
-local CAST_RANGE_BUFFER = 50
-local ORDER_COOLDOWN = 0.25
-local FOLLOW_ORDER_INTERVAL = 0.75
-local FOLLOW_DISTANCE_LEASH = 250
-local ABILITY_ORDER_COOLDOWN = 0.6
-local NO_TARGET_FALLBACK_RANGE = 350
+-------------------------------------------------------------------------------
+-- Utility helpers
+-------------------------------------------------------------------------------
+local function ResetRuntime()
+    runtime.hero = nil
+    runtime.hero_owner_id = nil
+    runtime.team = nil
+    runtime.player = nil
+    runtime.player_id = nil
+    runtime.config = nil
+    runtime.agents = {}
+    runtime.threat_expiry = {}
+    runtime.debug_font = nil
+end
 
-local SPECIAL_VALUE_KEYS = {
-    "radius",
-    "range",
-    "max_distance",
-    "distance",
-    "cast_range",
-    "cast_radius",
-    "aoe",
-    "area_of_effect",
-}
-
-local ABILITY_RULES = {
-    centaur_khan_war_stomp = { cast = "no_target", range = 325 },
-    hellbear_smasher_thunder_clap = { cast = "no_target", range = 350 },
-    polar_furbolg_ursa_warrior_thunder_clap = { cast = "no_target", range = 350 },
-    dark_troll_warlord_ensnare = { cast = "target", range = 550 },
-    satyr_hellcaller_shockwave = { cast = "point", range = 950 },
-    satyr_soulstealer_mana_burn = { cast = "target", range = 650 },
-    satyr_trickster_purge = { cast = "target", range = 350 },
-    mudgolem_hurl_boulder = { cast = "target", range = 800 },
-    rock_golem_hurl_boulder = { cast = "target", range = 800 },
-    greater_mudgolem_hurl_boulder = { cast = "target", range = 800 },
-    greater_rock_golem_hurl_boulder = { cast = "target", range = 800 },
-    big_thunder_lizard_slam = { cast = "no_target", range = 325 },
-    warpine_raider_seed_shot = { cast = "target", range = 600 },
-    ogre_bruiser_ogre_smash = { cast = "point", range = 275 },
-    harpy_storm_chain_lightning = { cast = "target", range = 650 },
-    black_dragon_fireball = { cast = "point", range = 1200 },
-    ancient_black_dragon_fireball = { cast = "point", range = 1200 },
-    granite_golem_hurl_boulder = { cast = "target", range = 900 },
-    ancient_rock_golem_hurl_boulder = { cast = "target", range = 900 },
-    ancient_thunderhide_slam = { cast = "no_target", range = 325 },
-}
-
-local NO_TARGET_WHITELIST = {
-    centaur_khan_war_stomp = true,
-    hellbear_smasher_thunder_clap = true,
-    polar_furbolg_ursa_warrior_thunder_clap = true,
-    ancient_thunderhide_slam = true,
-    big_thunder_lizard_slam = true,
-}
-
-local ABILITY_BLACKLIST = {
-    dark_troll_warlord_raise_dead = true,
-    enraged_wildkin_tornado = true,
-    ogre_magi_frost_armor = true,
-    ancient_thunderhide_frenzy = true,
-    big_thunder_lizard_frenzy = true,
-    forest_troll_high_priest_heal = true,
-}
-
-local last_cast_time = 0
-local creep_states = {}
-local ability_last_cast_times = {}
-
-local band = bit32 and bit32.band or (bit and bit.band)
-
-local function has_flag(value, flag)
-    if not value or not flag then
+local function IsValidHandle(handle)
+    if not handle then
         return false
     end
 
-    if band then
-        return band(value, flag) ~= 0
-    end
-
-    while value > 0 and flag > 0 do
-        if value % 2 == 1 and flag % 2 == 1 then
-            return true
-        end
-
-        value = math.floor(value / 2)
-        flag = math.floor(flag / 2)
-    end
-
-    return false
-end
-
-local function reset_state()
-    last_cast_time = 0
-    creep_states = {}
-    ability_last_cast_times = {}
-end
-
-local function get_creep_state(index)
-    local state = creep_states[index]
-    if not state then
-        state = { last_follow = 0 }
-        creep_states[index] = state
-    end
-
-    return state
-end
-
-local function cleanup_creep_states(active_indices)
-    for index in pairs(creep_states) do
-        if not active_indices[index] then
-            creep_states[index] = nil
-        end
-    end
-end
-
-local function record_ability_cast(ability, game_time)
-    local idx = Ability.GetIndex(ability)
-    if idx then
-        ability_last_cast_times[idx] = game_time
-    end
-end
-
-local function can_cast_now(ability, game_time)
-    local idx = Ability.GetIndex(ability)
-    if not idx then
-        return true
-    end
-
-    local last = ability_last_cast_times[idx]
-    if last and (game_time - last) < ABILITY_ORDER_COOLDOWN then
+    local t = type(handle)
+    if t ~= "userdata" and t ~= "table" then
         return false
+    end
+
+    local is_null = handle.IsNull
+    if type(is_null) == "function" then
+        local ok, result = pcall(is_null, handle)
+        if ok and result then
+            return false
+        end
     end
 
     return true
 end
 
-local function get_special_value(ability, key)
-    local ok, value = pcall(Ability.GetLevelSpecialValueFor, ability, key, -1)
-    if ok and type(value) == "number" then
-        return value
+local function EnsureFont()
+    if not runtime.debug_font then
+        runtime.debug_font = Render.LoadFont("Arial", 16, Enum.FontCreate.FONTFLAG_OUTLINE)
+    end
+    return runtime.debug_font
+end
+
+local function GetPlayerOwnerID(unit)
+    if NPC and NPC.GetPlayerOwnerID then
+        local ok, owner = pcall(NPC.GetPlayerOwnerID, unit)
+        if ok and type(owner) == "number" and owner >= 0 then
+            return owner
+        end
+    end
+
+    if Entity and Entity.GetPlayerOwnerID then
+        local ok, owner = pcall(Entity.GetPlayerOwnerID, unit)
+        if ok and type(owner) == "number" and owner >= 0 then
+            return owner
+        end
     end
 
     return nil
 end
 
-local function get_effective_range(ability, fallback)
-    local range = Ability.GetCastRange(ability)
-    if range and range > 0 then
-        return range
-    end
-
-    for _, key in ipairs(SPECIAL_VALUE_KEYS) do
-        local value = get_special_value(ability, key)
-        if value and value > 0 then
-            return value
+local function GetEntityOwner(unit)
+    if Entity and Entity.GetOwner then
+        local ok, owner = pcall(Entity.GetOwner, unit)
+        if ok and owner and owner ~= unit then
+            return owner
         end
     end
-
-    return fallback
+    return nil
 end
 
-local function is_big_neutral(npc)
-    if not npc or not Entity.IsNPC(npc) then
+local function IsOwnedByHero(unit)
+    if not runtime.hero then
         return false
     end
 
-    if not Entity.IsAlive(npc) or Entity.IsDormant(npc) then
-        return false
-    end
-
-    if not NPC.IsNeutral(npc) or NPC.IsAncient(npc) then
-        return false
-    end
-
-    local name = NPC.GetUnitName(npc)
-    if name and BIG_NEUTRAL_NAMES[name] then
-        return true
-    end
-
-    local max_health = Entity.GetMaxHealth(npc)
-    if max_health and max_health >= BIG_NEUTRAL_MIN_HEALTH then
-        return true
+    local current = unit
+    local safety = 0
+    while current and safety < 10 do
+        if current == runtime.hero then
+            return true
+        end
+        current = GetEntityOwner(current)
+        safety = safety + 1
     end
 
     return false
 end
 
-local function get_dominator_item(hero)
-    for _, item_name in ipairs(DOMINATOR_ITEMS) do
-        local item = NPC.GetItem(hero, item_name, true)
-        if item and Ability.IsReady(item) then
-            return item
+local function AcquirePlayerHandle()
+    if IsValidHandle(runtime.player) then
+        return runtime.player
+    end
+
+    runtime.player = nil
+
+    if runtime.player_id then
+        if PlayerResource and PlayerResource.GetPlayer then
+            local ok, candidate = pcall(PlayerResource.GetPlayer, runtime.player_id)
+            if ok and IsValidHandle(candidate) then
+                runtime.player = candidate
+                return runtime.player
+            end
+        end
+
+        if Players and Players.GetPlayer then
+            local ok, candidate = pcall(Players.GetPlayer, runtime.player_id)
+            if ok and IsValidHandle(candidate) then
+                runtime.player = candidate
+                return runtime.player
+            end
+        end
+    end
+
+    if Players and Players.GetLocal then
+        local ok, candidate = pcall(Players.GetLocal)
+        if ok and IsValidHandle(candidate) then
+            runtime.player = candidate
+            if Player and Player.GetPlayerID then
+                local ok_id, pid = pcall(Player.GetPlayerID, candidate)
+                if ok_id and type(pid) == "number" and pid >= 0 then
+                    runtime.player_id = pid
+                end
+            end
+            return runtime.player
         end
     end
 
     return nil
 end
 
-local function find_best_target(origin, range)
-    local best_target = nil
-    local best_health = -1
+local function UpdateHeroContext()
+    runtime.hero = Heroes and Heroes.GetLocal and Heroes.GetLocal() or nil
+    if not runtime.hero or not Entity.IsAlive(runtime.hero) then
+        ResetRuntime()
+        return false
+    end
 
-    for _, npc in pairs(NPCs.GetAll()) do
-        if is_big_neutral(npc) then
-            local npc_pos = Entity.GetAbsOrigin(npc)
-            local distance = npc_pos:Distance2D(origin)
-            if distance <= range then
-                local health = Entity.GetHealth(npc) or 0
-                if health > best_health then
-                    best_health = health
-                    best_target = npc
+    runtime.team = Entity.GetTeamNum(runtime.hero)
+
+    local owner_id = GetPlayerOwnerID(runtime.hero)
+    if not owner_id and Hero and Hero.GetPlayerID then
+        local ok, pid = pcall(Hero.GetPlayerID, runtime.hero)
+        if ok and type(pid) == "number" and pid >= 0 then
+            owner_id = pid
+        end
+    end
+
+    runtime.hero_owner_id = owner_id
+
+    if owner_id and owner_id >= 0 then
+        runtime.player_id = runtime.player_id or owner_id
+    end
+
+    AcquirePlayerHandle()
+    return true
+end
+
+-------------------------------------------------------------------------------
+-- Menu configuration
+-------------------------------------------------------------------------------
+local function EnsureMenu()
+    if runtime.menu_ready then
+        return
+    end
+
+    if not Menu or not Menu.Create then
+        return
+    end
+
+    local tab = Menu.Create("Scripts", "Other", "Unit Commander")
+    if not tab then
+        return
+    end
+
+    tab:Icon("\u{f0c0}")
+
+    local main_group = tab:Create("Main")
+    local settings = main_group:Create("Settings")
+
+    agent_script.ui.enable = settings:Switch("Включить Unit Commander", true, "\u{f0c0}")
+    agent_script.ui.enable:ToolTip("Автоматически управлять всеми подвластными юнитами, кроме героя и курьера.")
+
+    agent_script.ui.debug = settings:Switch("Показать отладку", true, "\u{f05a}")
+    agent_script.ui.debug:ToolTip("Показывать крупные подписи над юнитами с их текущим состоянием.")
+
+    agent_script.ui.follow_distance = settings:Slider("Дистанция следования", 100, 900, 400, "%d")
+    agent_script.ui.follow_distance:ToolTip("Как далеко юниты могут отходить от героя до начала преследования.")
+
+    agent_script.ui.attack_radius = settings:Slider("Радиус агрессии", 300, 2000, 900, "%d")
+    agent_script.ui.attack_radius:ToolTip("Максимальная дистанция поиска целей для атаки.")
+
+    agent_script.ui.order_cooldown = settings:Slider("Задержка приказов (сек)", 10, 200, 50, "%.1f")
+    agent_script.ui.order_cooldown:ToolTip("Минимальный интервал между приказами (значение делится на 100).")
+
+    agent_script.ui.channel_wait = settings:Slider("Задержка после канала (сек)", 10, 200, 20, "%.1f")
+    agent_script.ui.channel_wait:ToolTip("Ожидание после начала канала способности (значение делится на 100).")
+
+    agent_script.ui.manual_override = settings:Slider("Ручное управление (сек)", 50, 500, 250, "%.1f")
+    agent_script.ui.manual_override:ToolTip("Сколько секунд AI не вмешивается после вашего приказа (значение делится на 100).")
+
+    runtime.menu_ready = true
+end
+
+local function ReadConfig()
+    if not runtime.menu_ready then
+        EnsureMenu()
+    end
+
+    runtime.config = runtime.config or {}
+
+    local function slider_value(slider)
+        if not slider then
+            return 0
+        end
+        return (slider:Get() or 0) / 100
+    end
+
+    runtime.config.enabled = agent_script.ui.enable and agent_script.ui.enable:Get() or false
+    runtime.config.debug = agent_script.ui.debug and agent_script.ui.debug:Get() or false
+    runtime.config.follow_distance = (agent_script.ui.follow_distance and agent_script.ui.follow_distance:Get() or 400)
+    runtime.config.attack_radius = (agent_script.ui.attack_radius and agent_script.ui.attack_radius:Get() or 900)
+    runtime.config.order_cooldown = slider_value(agent_script.ui.order_cooldown)
+    runtime.config.channel_wait = slider_value(agent_script.ui.channel_wait)
+    runtime.config.manual_override = slider_value(agent_script.ui.manual_override)
+
+    if runtime.config.order_cooldown < 0.05 then
+        runtime.config.order_cooldown = 0.05
+    end
+    if runtime.config.channel_wait < 0.05 then
+        runtime.config.channel_wait = 0.05
+    end
+    if runtime.config.manual_override < 0.1 then
+        runtime.config.manual_override = 0.1
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Ability metadata
+-------------------------------------------------------------------------------
+local ABILITY_DATA = {
+    mud_golem_hurl_boulder = {
+        behavior = "target",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Бросаю валун",
+        aliases = {
+            "ancient_rock_golem_hurl_boulder",
+            "granite_golem_hurl_boulder",
+        },
+    },
+    dark_troll_warlord_ensnare = {
+        behavior = "target",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Бросаю сеть",
+    },
+    dark_troll_warlord_raise_dead = {
+        behavior = "no_target",
+        always_cast = true,
+        ignore_is_castable = true,
+        message = "Призываю скелетов",
+        aliases = {
+            "dark_troll_summoner_raise_dead",
+            "dark_troll_warlord_raise_dead_datadriven",
+        },
+    },
+    forest_troll_high_priest_heal = {
+        behavior = "ally_target",
+        prefer_anchor = true,
+        prefer_ally_hero = true,
+        ally_max_health_pct = 0.92,
+        message = "Лечу союзника",
+    },
+    satyr_hellcaller_shockwave = {
+        behavior = "point",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Шоковая волна",
+    },
+    satyr_trickster_purge = {
+        behavior = "target",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Снимаю эффекты",
+    },
+    satyr_soulstealer_mana_burn = {
+        behavior = "target",
+        only_heroes = true,
+        min_mana = 75,
+        message = "Выжигаю ману",
+        aliases = {
+            "satyr_mindstealer_mana_burn",
+        },
+    },
+    harpy_storm_chain_lightning = {
+        behavior = "target",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Цепная молния",
+    },
+    centaur_khan_war_stomp = {
+        behavior = "no_target",
+        radius = 315,
+        min_enemies = 1,
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Оглушаю врагов",
+    },
+    polar_furbolg_ursa_warrior_thunder_clap = {
+        behavior = "no_target",
+        radius = 315,
+        min_enemies = 1,
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Громовой удар",
+        aliases = {
+            "polar_furbolg_champion_thunder_clap",
+        },
+    },
+    hellbear_smasher_slam = {
+        behavior = "no_target",
+        radius = 350,
+        min_enemies = 1,
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Мощный удар",
+    },
+    ogre_bruiser_ogre_smash = {
+        behavior = "point",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Размазываю врага",
+        range_bonus = 50,
+        aliases = {
+            "ogre_mauler_smash",
+        },
+    },
+    neutral_ogre_magi_ice_armor = {
+        behavior = "ally_target",
+        prefer_anchor = true,
+        prefer_ally_hero = true,
+        avoid_modifier = "modifier_ogre_magi_frost_armor",
+        message = "Накладываю броню",
+        aliases = {
+            "ogre_magi_frost_armor",
+        },
+    },
+    ancient_black_dragon_fireball = {
+        behavior = "point",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Огненный шар",
+        aliases = {
+            "black_dragon_fireball",
+        },
+    },
+    ancient_thunderhide_slam = {
+        behavior = "no_target",
+        radius = 315,
+        min_enemies = 1,
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Громовой топот",
+        aliases = {
+            "big_thunder_lizard_slam",
+        },
+    },
+    ancient_thunderhide_frenzy = {
+        behavior = "ally_target",
+        prefer_anchor = true,
+        include_self = false,
+        message = "Бешенство",
+        aliases = {
+            "big_thunder_lizard_frenzy",
+        },
+    },
+    fel_beast_haunt = {
+        behavior = "target",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Пугаю врага",
+    },
+    enraged_wildkin_tornado = {
+        behavior = "point",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Призываю торнадо",
+        aliases = {
+            "wildkin_tornado",
+        },
+    },
+    wildkin_hurricane = {
+        behavior = "point",
+        allow_creeps = true,
+        allow_neutrals = true,
+        message = "Сильный порыв",
+    },
+    prowler_acolyte_heal = {
+        behavior = "ally_target",
+        prefer_ally_hero = true,
+        ally_max_health_pct = 0.85,
+        message = "Лечу союзника",
+    },
+    kobold_taskmaster_speed_aura = {
+        behavior = "no_target",
+        always_cast = true,
+        ignore_is_castable = true,
+        message = "Ускоряю отряд",
+    },
+    neutral_spell_immunity = {
+        behavior = "no_target",
+        always_cast = true,
+        message = "Щит",
+    },
+}
+
+local function ExpandAbilityAliases()
+    local pending = {}
+    for name, metadata in pairs(ABILITY_DATA) do
+        if metadata.aliases then
+            for _, alias in ipairs(metadata.aliases) do
+                if not ABILITY_DATA[alias] then
+                    table.insert(pending, { alias, metadata })
+                end
+            end
+        end
+    end
+
+    for _, entry in ipairs(pending) do
+        ABILITY_DATA[entry[1]] = entry[2]
+    end
+end
+
+ExpandAbilityAliases()
+
+-------------------------------------------------------------------------------
+-- Ability helpers
+-------------------------------------------------------------------------------
+local function GetAbilityCharges(ability)
+    if not ability then
+        return nil
+    end
+
+    local readers = {
+        "GetCurrentAbilityCharges",
+        "GetCurrentCharges",
+        "GetRemainingCharges",
+        "GetCharges",
+    }
+
+    for _, name in ipairs(readers) do
+        local getter = Ability[name]
+        if type(getter) == "function" then
+            local ok, value = pcall(getter, ability)
+            if ok and type(value) == "number" then
+                return value
+            end
+        end
+    end
+
+    return nil
+end
+
+local function IsAbilityReady(unit, ability, metadata)
+    if not ability then
+        return false
+    end
+
+    if Ability.GetLevel and Ability.GetLevel(ability) <= 0 then
+        return false
+    end
+
+    if Ability.IsHidden and Ability.IsHidden(ability) then
+        return false
+    end
+
+    if Ability.IsPassive and Ability.IsPassive(ability) then
+        return false
+    end
+
+    if Ability.GetCooldownTimeRemaining then
+        local ok, remaining = pcall(Ability.GetCooldownTimeRemaining, ability)
+        if ok and remaining and remaining > 0 then
+            return false
+        end
+    end
+
+    if metadata and metadata.requires_charges then
+        local charges = GetAbilityCharges(ability)
+        if not charges or charges <= 0 then
+            return false
+        end
+    end
+
+    if metadata and metadata.ignore_is_castable then
+        return true
+    end
+
+    if Ability.IsReady then
+        local ok, ready = pcall(Ability.IsReady, ability)
+        if ok and ready then
+            return true
+        end
+    end
+
+    if Ability.IsCastable then
+        local ok, castable = pcall(Ability.IsCastable, ability, NPC.GetMana(unit))
+        if ok then
+            return castable
+        end
+    end
+
+    return false
+end
+
+local function GetAbilityCastRange(unit, ability, metadata)
+    if metadata and metadata.range then
+        return metadata.range
+    end
+
+    if Ability.GetCastRange then
+        local ok, range = pcall(Ability.GetCastRange, ability)
+        if ok and range and range > 0 then
+            return range
+        end
+    end
+
+    if ability and Ability.GetSpecialValueFor then
+        local ok, value = pcall(Ability.GetSpecialValueFor, ability, "cast_range")
+        if ok and value and value > 0 then
+            return value
+        end
+    end
+
+    return 600
+end
+
+local function SafeOrder(unit, order, target, position, ability)
+    local player = AcquirePlayerHandle()
+    if not player then
+        return
+    end
+
+    Player.PrepareUnitOrders(
+        player,
+        order,
+        target,
+        position,
+        ability,
+        Enum.PlayerOrderIssuer.DOTA_ORDER_ISSUER_PASSED_UNIT_ONLY,
+        unit
+    )
+end
+
+local function SafeCastTarget(unit, ability, target)
+    if Ability.CastTarget then
+        local ok = pcall(Ability.CastTarget, ability, target)
+        if ok then
+            return
+        end
+    end
+    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_TARGET, target, nil, ability)
+end
+
+local function SafeCastPosition(unit, ability, position)
+    if Ability.CastPosition then
+        local ok = pcall(Ability.CastPosition, ability, position)
+        if ok then
+            return
+        end
+    end
+    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_POSITION, nil, position, ability)
+end
+
+local function SafeCastNoTarget(unit, ability)
+    if Ability.CastNoTarget then
+        local ok = pcall(Ability.CastNoTarget, ability)
+        if ok then
+            return
+        end
+    end
+    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_CAST_NO_TARGET, nil, nil, ability)
+end
+
+local function GetUnitHealthPercent(unit)
+    if not unit or not Entity.IsAlive(unit) then
+        return 0
+    end
+
+    local health = Entity.GetHealth(unit) or 0
+    local max_health = Entity.GetMaxHealth(unit) or 0
+
+    if max_health <= 0 then
+        return 0
+    end
+
+    return health / max_health
+end
+
+local function EnemyMatches(enemy, metadata)
+    if not enemy or not Entity.IsAlive(enemy) then
+        return false
+    end
+
+    if Entity.GetTeamNum(enemy) == runtime.team then
+        return false
+    end
+
+    if NPC.IsCourier and NPC.IsCourier(enemy) then
+        return false
+    end
+
+    local is_hero = NPC.IsHero(enemy)
+    local is_creep = NPC.IsCreep(enemy) and not is_hero
+    local is_neutral = Entity.GetTeamNum(enemy) == Enum.TeamNum.TEAM_NEUTRAL
+
+    if metadata then
+        if metadata.only_heroes and not is_hero then
+            return false
+        end
+        if is_creep and metadata.allow_creeps == false then
+            return false
+        end
+        if is_neutral and metadata.allow_neutrals == false then
+            return false
+        end
+        if metadata.min_mana and NPC.GetMana(enemy) < metadata.min_mana then
+            return false
+        end
+        if metadata.avoid_modifier and NPC.HasModifier(enemy, metadata.avoid_modifier) then
+            return false
+        end
+    end
+
+    return true
+end
+
+local function AllyMatches(ally, metadata)
+    if not ally or not Entity.IsAlive(ally) then
+        return false
+    end
+
+    if metadata then
+        if metadata.include_self == false and ally == runtime.hero then
+            return false
+        end
+        if metadata.ally_max_health_pct then
+            if GetUnitHealthPercent(ally) >= metadata.ally_max_health_pct then
+                return false
+            end
+        end
+        if metadata.ally_min_health_pct then
+            if GetUnitHealthPercent(ally) <= metadata.ally_min_health_pct then
+                return false
+            end
+        end
+        if metadata.avoid_modifier and NPC.HasModifier(ally, metadata.avoid_modifier) then
+            return false
+        end
+    end
+
+    return true
+end
+
+local function FindEnemyTarget(unit, metadata, cast_range, current_target, anchor_pos)
+    local unit_pos = Entity.GetAbsOrigin(unit)
+    local centers = {}
+
+    if unit_pos then
+        centers[#centers + 1] = unit_pos
+    end
+    if anchor_pos then
+        centers[#centers + 1] = anchor_pos
+    end
+
+    local best_target
+    local best_score = -math.huge
+
+    if current_target and EnemyMatches(current_target, metadata) then
+        local pos = Entity.GetAbsOrigin(current_target)
+        if pos and unit_pos and unit_pos:Distance(pos) <= cast_range + (metadata and metadata.range_bonus or 0) then
+            best_target = current_target
+            best_score = 1000
+        end
+    end
+
+    for _, center in ipairs(centers) do
+        local enemies = NPCs.InRadius(center, cast_range + (metadata and metadata.range_bonus or 0), runtime.team, Enum.TeamType.TEAM_ENEMY) or {}
+        for _, enemy in ipairs(enemies) do
+            if EnemyMatches(enemy, metadata) then
+                local pos = Entity.GetAbsOrigin(enemy)
+                if pos then
+                    local distance = center:Distance(pos)
+                    if distance <= cast_range + (metadata and metadata.range_bonus or 0) then
+                        local score = -distance
+                        if NPC.IsHero(enemy) then
+                            score = score + 300
+                        end
+
+                        local idx = Entity.GetIndex(enemy)
+                        if runtime.threat_expiry[idx] and runtime.threat_expiry[idx] > GlobalVars.GetCurTime() then
+                            score = score + 150
+                        end
+
+                        if score > best_score then
+                            best_score = score
+                            best_target = enemy
+                        end
+                    end
+                end
+            end
+        end
+
+        if metadata and metadata.allow_neutrals ~= false then
+            local neutrals = NPCs.InRadius(center, cast_range + (metadata and metadata.range_bonus or 0), runtime.team, Enum.TeamType.TEAM_NEUTRAL) or {}
+            for _, enemy in ipairs(neutrals) do
+                if EnemyMatches(enemy, metadata) then
+                    local pos = Entity.GetAbsOrigin(enemy)
+                    if pos then
+                        local distance = center:Distance(pos)
+                        if distance <= cast_range + (metadata and metadata.range_bonus or 0) then
+                            local score = -distance
+                            if score > best_score then
+                                best_score = score
+                                best_target = enemy
+                            end
+                        end
+                    end
                 end
             end
         end
@@ -235,186 +768,164 @@ local function find_best_target(origin, range)
     return best_target
 end
 
-local function collect_enemy_heroes(hero)
-    local enemies = {}
-
-    for _, enemy in pairs(Heroes.GetAll()) do
-        if enemy ~= hero and Entity.IsAlive(enemy) and not Entity.IsDormant(enemy) and not Entity.IsSameTeam(hero, enemy) then
-            table.insert(enemies, enemy)
+local function ChooseAllyTarget(unit, metadata, cast_range, anchor_unit, anchor_pos)
+    if metadata and metadata.prefer_anchor and anchor_unit and AllyMatches(anchor_unit, metadata) then
+        local anchor_position = anchor_pos or Entity.GetAbsOrigin(anchor_unit)
+        local unit_pos = Entity.GetAbsOrigin(unit)
+        if anchor_position and unit_pos and unit_pos:Distance(anchor_position) <= cast_range + (metadata and metadata.range_bonus or 0) then
+            return anchor_unit
         end
     end
 
-    return enemies
-end
-
-local function is_controlled_creep(hero, npc, player_id)
-    if npc == hero then
-        return false
-    end
-
-    if not npc or not Entity.IsNPC(npc) or Entity.IsDormant(npc) or not Entity.IsAlive(npc) then
-        return false
-    end
-
-    if NPC.IsHero(npc) or NPC.IsIllusion(npc) then
-        return false
-    end
-
-    local is_creep = NPC.IsCreep(npc)
-    local is_ancient = NPC.IsAncient(npc)
-    if not is_creep and not is_ancient then
-        return false
-    end
-
-    if NPC.IsLaneCreep(npc) then
-        return false
-    end
-
-    if not Entity.IsSameTeam(hero, npc) then
-        return false
-    end
-
-    if player_id and player_id >= 0 and not NPC.IsControllableByPlayer(npc, player_id) then
-        return false
-    end
-
-    return true
-end
-
-local function collect_controlled_creeps(hero)
-    local player = Players.GetLocal()
-    local player_id = nil
-
-    if player then
-        player_id = Player.GetPlayerID(player)
-        if player_id and player_id < 0 then
-            player_id = nil
+    if metadata and metadata.prefer_ally_hero and runtime.hero and AllyMatches(runtime.hero, metadata) then
+        local hero_pos = Entity.GetAbsOrigin(runtime.hero)
+        local unit_pos = Entity.GetAbsOrigin(unit)
+        if hero_pos and unit_pos and unit_pos:Distance(hero_pos) <= cast_range + (metadata and metadata.range_bonus or 0) then
+            return runtime.hero
         end
     end
 
-    local creeps = {}
-    local active_indices = {}
-
-    for _, npc in pairs(NPCs.GetAll()) do
-        if is_controlled_creep(hero, npc, player_id) then
-            table.insert(creeps, npc)
-            active_indices[Entity.GetIndex(npc)] = true
-        end
+    local unit_pos = Entity.GetAbsOrigin(unit)
+    if not unit_pos then
+        return nil
     end
 
-    cleanup_creep_states(active_indices)
+    local best_target
+    local best_score = -math.huge
 
-    return creeps
-end
-
-local function find_enemy_in_range(enemies, source_pos, range)
-    local best_target = nil
-    local best_distance = math.huge
-
-    for _, enemy in ipairs(enemies) do
-        if not NPC.IsIllusion(enemy) then
-            local enemy_pos = Entity.GetAbsOrigin(enemy)
-            local distance = enemy_pos:Distance2D(source_pos)
-            if distance <= range and distance < best_distance then
-                best_target = enemy
-                best_distance = distance
+    local friends = NPCs.InRadius(unit_pos, cast_range + (metadata and metadata.range_bonus or 0), runtime.team, Enum.TeamType.TEAM_FRIEND) or {}
+    for _, ally in ipairs(friends) do
+        if AllyMatches(ally, metadata) then
+            local pos = Entity.GetAbsOrigin(ally)
+            if pos then
+                local distance = unit_pos:Distance(pos)
+                if distance <= cast_range + (metadata and metadata.range_bonus or 0) then
+                    local score = -distance
+                    if NPC.IsHero(ally) then
+                        score = score + 120
+                    end
+                    if score > best_score then
+                        best_score = score
+                        best_target = ally
+                    end
+                end
             end
         end
     end
 
-    return best_target, best_distance
+    return best_target
 end
 
-local function cast_creep_ability(creep, ability, enemies, game_time)
-    if not ability then
+local function ShouldCastNoTargetAbility(unit, metadata, ability)
+    if metadata and metadata.always_cast then
+        return true
+    end
+
+    local radius = metadata and metadata.radius
+    if not radius and Ability.GetAOERadius then
+        local ok, value = pcall(Ability.GetAOERadius, ability)
+        if ok and value and value > 0 then
+            radius = value
+        end
+    end
+    radius = radius or 250
+
+    local unit_pos = Entity.GetAbsOrigin(unit)
+    if not unit_pos then
         return false
     end
 
-    local ability_name = Ability.GetName(ability)
-    if not ability_name or ABILITY_BLACKLIST[ability_name] then
-        return false
-    end
+    local enemies = NPCs.InRadius(unit_pos, radius, runtime.team, Enum.TeamType.TEAM_ENEMY) or {}
+    local neutrals = NPCs.InRadius(unit_pos, radius, runtime.team, Enum.TeamType.TEAM_NEUTRAL) or {}
 
-    if Ability.GetLevel(ability) <= 0 or Ability.IsHidden(ability) or not Ability.IsActivated(ability) then
-        return false
-    end
-
-    if not Ability.IsReady(ability) or not Ability.IsOwnersManaEnough(ability) or not can_cast_now(ability, game_time) then
-        return false
-    end
-
-    local behavior = Ability.GetBehavior(ability)
-    if has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_PASSIVE) then
-        return false
-    end
-
-    if has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_CHANNELLED) then
-        return false
-    end
-
-    local config = ABILITY_RULES[ability_name]
-    local cast_type = config and config.cast
-
-    if not cast_type then
-        if has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_UNIT_TARGET) then
-            cast_type = "target"
-        elseif has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_POINT) then
-            cast_type = "point"
-        elseif has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_NO_TARGET) then
-            cast_type = "no_target"
-        else
-            return false
+    local total = 0
+    for _, enemy in ipairs(enemies) do
+        if EnemyMatches(enemy, metadata) then
+            total = total + 1
         end
     end
 
-    local target_team = Ability.GetTargetTeam(ability)
-    if (cast_type == "target" or cast_type == "point")
-        and target_team ~= Enum.TargetTeam.DOTA_UNIT_TARGET_TEAM_ENEMY
-        and target_team ~= Enum.TargetTeam.DOTA_UNIT_TARGET_TEAM_BOTH then
+    if metadata and metadata.allow_neutrals ~= false then
+        for _, enemy in ipairs(neutrals) do
+            if EnemyMatches(enemy, metadata) then
+                total = total + 1
+            end
+        end
+    end
+
+    local minimum = 1
+    if metadata and metadata.min_enemies then
+        minimum = metadata.min_enemies
+    end
+
+    return total >= minimum
+end
+
+local function TryCastAbility(unit, agent, now, ability, metadata, current_target, anchor_unit, anchor_pos)
+    if not IsAbilityReady(unit, ability, metadata) then
         return false
     end
 
-    if cast_type == "no_target" and not (config or NO_TARGET_WHITELIST[ability_name]) then
-        local damage = Ability.GetDamage(ability)
-        if not damage or damage <= 0 then
-            return false
-        end
-    end
+    local behavior = metadata and metadata.behavior
+    local cast_range = GetAbilityCastRange(unit, ability, metadata)
 
-    local fallback = cast_type == "no_target" and NO_TARGET_FALLBACK_RANGE or 700
-    local range = config and config.range or get_effective_range(ability, fallback)
-    if not range or range <= 0 then
-        range = fallback
-    end
-
-    local creep_pos = Entity.GetAbsOrigin(creep)
-
-    if cast_type == "target" then
-        if range < 0 then
-            range = 0
-        end
-        local target = find_enemy_in_range(enemies, creep_pos, range)
-        if target then
-            Ability.CastTarget(ability, target)
-            record_ability_cast(ability, game_time)
+    if behavior == "target" then
+        local enemy = FindEnemyTarget(unit, metadata, cast_range, current_target, anchor_pos)
+        if enemy then
+            SafeCastTarget(unit, ability, enemy)
+            agent.last_action = metadata and metadata.message or "Использую способность"
+            agent.next_order_time = now + runtime.config.order_cooldown
             return true
         end
-    elseif cast_type == "point" then
-        local target = find_enemy_in_range(enemies, creep_pos, range)
-        if target then
-            local pos = Entity.GetAbsOrigin(target)
-            Ability.CastPosition(ability, pos)
-            record_ability_cast(ability, game_time)
+    elseif behavior == "point" then
+        local enemy = FindEnemyTarget(unit, metadata, cast_range, current_target, anchor_pos)
+        local cast_pos = enemy and Entity.GetAbsOrigin(enemy)
+        if not cast_pos and metadata and metadata.always_cast then
+            cast_pos = Entity.GetAbsOrigin(unit)
+        end
+        if cast_pos then
+            SafeCastPosition(unit, ability, cast_pos)
+            agent.last_action = metadata and metadata.message or "Использую способность"
+            agent.next_order_time = now + runtime.config.order_cooldown
             return true
         end
-    elseif cast_type == "no_target" then
-        local radius = range > 0 and range or NO_TARGET_FALLBACK_RANGE
-        for _, enemy in ipairs(enemies) do
-            local enemy_pos = Entity.GetAbsOrigin(enemy)
-            if enemy_pos:Distance2D(creep_pos) <= radius then
-                Ability.CastNoTarget(ability)
-                record_ability_cast(ability, game_time)
-                return true
+    elseif behavior == "no_target" then
+        if ShouldCastNoTargetAbility(unit, metadata, ability) then
+            SafeCastNoTarget(unit, ability)
+            agent.last_action = metadata and metadata.message or "Использую способность"
+            agent.next_order_time = now + runtime.config.order_cooldown
+            return true
+        end
+    elseif behavior == "ally_target" then
+        local ally = ChooseAllyTarget(unit, metadata, cast_range, anchor_unit, anchor_pos)
+        if ally then
+            SafeCastTarget(unit, ability, ally)
+            agent.last_action = metadata and metadata.message or "Поддерживаю союзника"
+            agent.next_order_time = now + runtime.config.order_cooldown
+            return true
+        end
+    end
+
+    return false
+end
+
+local function TryCastAbilities(unit, agent, now, current_target, anchor_unit, anchor_pos)
+    if NPC.IsChannellingAbility and NPC.IsChannellingAbility(unit) then
+        agent.state = STATES.ENGAGE
+        agent.last_action = "Канализирую"
+        agent.next_order_time = now + runtime.config.channel_wait
+        return true
+    end
+
+    for slot = 0, 23 do
+        local ability = NPC.GetAbilityByIndex(unit, slot)
+        if ability then
+            local name = Ability.GetName(ability)
+            local metadata = ABILITY_DATA[name]
+            if metadata then
+                if TryCastAbility(unit, agent, now, ability, metadata, current_target, anchor_unit, anchor_pos) then
+                    return true
+                end
             end
         end
     end
@@ -422,96 +933,325 @@ local function cast_creep_ability(creep, ability, enemies, game_time)
     return false
 end
 
-local function handle_auto_dominator(hero, game_time)
-    if NPC.IsStunned(hero) or NPC.IsChannellingAbility(hero) then
-        return
-    end
-
-    local dominator = get_dominator_item(hero)
-    if not dominator then
-        return
-    end
-
-    local mana = NPC.GetMana(hero)
-    if not Ability.IsCastable(dominator, mana) then
-        return
-    end
-
-    if last_cast_time > 0 and (game_time - last_cast_time) < ORDER_COOLDOWN then
-        return
-    end
-
-    local hero_origin = Entity.GetAbsOrigin(hero)
-    local cast_range = Ability.GetCastRange(dominator) or 0
-    if cast_range < 0 then
-        cast_range = 0
-    end
-    cast_range = cast_range + CAST_RANGE_BUFFER
-
-    local target = find_best_target(hero_origin, cast_range)
-    if not target then
-        return
-    end
-
-    Ability.CastTarget(dominator, target)
-    last_cast_time = game_time
+-------------------------------------------------------------------------------
+-- Agent management
+-------------------------------------------------------------------------------
+local function CreateAgent(unit)
+    return {
+        unit = unit,
+        handle = Entity.GetIndex(unit),
+        state = STATES.FOLLOW,
+        last_action = "Инициализация",
+        next_order_time = 0,
+        manual_until = 0,
+        current_target = nil,
+    }
 end
 
-local function handle_controlled_creeps(hero, game_time)
-    local creeps = collect_controlled_creeps(hero)
-    if #creeps == 0 then
-        return
+local function MoveToPosition(unit, position, agent, now)
+    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_MOVE_TO_POSITION, nil, position, nil)
+    agent.state = STATES.FOLLOW
+    agent.last_action = "Следую к герою"
+    agent.next_order_time = now + runtime.config.order_cooldown
+end
+
+local function HoldPosition(unit, agent, now)
+    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_HOLD_POSITION, nil, Entity.GetAbsOrigin(unit), nil)
+    agent.state = STATES.FOLLOW
+    agent.last_action = "Ожидаю"
+    agent.next_order_time = now + runtime.config.order_cooldown
+end
+
+local function AttackTarget(unit, target, agent, now)
+    SafeOrder(unit, Enum.UnitOrder.DOTA_UNIT_ORDER_ATTACK_TARGET, target, nil, nil)
+    agent.state = STATES.ENGAGE
+    local target_name = NPC.GetUnitName(target) or "цель"
+    agent.last_action = string.format("Атакую %s", target_name)
+    agent.current_target = target
+    agent.next_order_time = now + runtime.config.order_cooldown
+end
+
+local function AcquireAttackTarget(unit, anchor_pos)
+    local radius = runtime.config.attack_radius or 900
+    local unit_pos = Entity.GetAbsOrigin(unit)
+    local centers = {}
+    if unit_pos then
+        centers[#centers + 1] = unit_pos
+    end
+    if anchor_pos then
+        centers[#centers + 1] = anchor_pos
     end
 
-    local enemies = collect_enemy_heroes(hero)
-    local hero_pos = Entity.GetAbsOrigin(hero)
+    local best_target
+    local best_score = -math.huge
 
-    for _, creep in ipairs(creeps) do
-        local index = Entity.GetIndex(creep)
-        local state = get_creep_state(index)
-
-        if state then
-            local creep_pos = Entity.GetAbsOrigin(creep)
-            if creep_pos:Distance2D(hero_pos) > FOLLOW_DISTANCE_LEASH then
-                if game_time - (state.last_follow or 0) >= FOLLOW_ORDER_INTERVAL then
-                    NPC.MoveTo(creep, hero_pos)
-                    state.last_follow = game_time
+    for _, center in ipairs(centers) do
+        local enemies = NPCs.InRadius(center, radius, runtime.team, Enum.TeamType.TEAM_ENEMY) or {}
+        for _, enemy in ipairs(enemies) do
+            if Entity.IsAlive(enemy) and Entity.GetTeamNum(enemy) ~= runtime.team and (not NPC.IsCourier(enemy)) then
+                local pos = Entity.GetAbsOrigin(enemy)
+                if pos then
+                    local distance = center:Distance(pos)
+                    local score = -distance
+                    if NPC.IsHero(enemy) then
+                        score = score + 400
+                    end
+                    local idx = Entity.GetIndex(enemy)
+                    if runtime.threat_expiry[idx] and runtime.threat_expiry[idx] > GlobalVars.GetCurTime() then
+                        score = score + 200
+                    end
+                    if score > best_score then
+                        best_score = score
+                        best_target = enemy
+                    end
                 end
             end
         end
 
-        local can_use_abilities = #enemies > 0
-            and not NPC.IsStunned(creep)
-            and not NPC.IsSilenced(creep)
-            and not NPC.IsChannellingAbility(creep)
-
-        if can_use_abilities then
-            for slot = 0, 5 do
-                local ability = NPC.GetAbilityByIndex(creep, slot)
-                if cast_creep_ability(creep, ability, enemies, game_time) then
-                    break
+        local neutrals = NPCs.InRadius(center, radius, runtime.team, Enum.TeamType.TEAM_NEUTRAL) or {}
+        for _, enemy in ipairs(neutrals) do
+            if Entity.IsAlive(enemy) then
+                local pos = Entity.GetAbsOrigin(enemy)
+                if pos then
+                    local distance = center:Distance(pos)
+                    local score = -distance
+                    if score > best_score then
+                        best_score = score
+                        best_target = enemy
+                    end
                 end
             end
         end
     end
+
+    return best_target
 end
 
-function auto_dominator.OnUpdate()
+local function ProcessAgent(agent, now)
+    local unit = agent.unit
+    if not unit or not Entity.IsAlive(unit) then
+        return
+    end
+
+    local manual_remaining = agent.manual_until - now
+    if manual_remaining > 0 then
+        agent.state = STATES.MANUAL
+        agent.last_action = string.format("Ручное управление (%.1f)", manual_remaining)
+        return
+    end
+
+    if now < agent.next_order_time then
+        return
+    end
+
+    local anchor_unit = runtime.hero
+    local anchor_pos = anchor_unit and Entity.GetAbsOrigin(anchor_unit)
+    local current_target = agent.current_target
+
+    if TryCastAbilities(unit, agent, now, current_target, anchor_unit, anchor_pos) then
+        return
+    end
+
+    if agent.current_target and (not Entity.IsAlive(agent.current_target) or Entity.GetTeamNum(agent.current_target) == runtime.team) then
+        agent.current_target = nil
+    end
+
+    local target = AcquireAttackTarget(unit, anchor_pos)
+    if target then
+        AttackTarget(unit, target, agent, now)
+        return
+    end
+
+    if anchor_pos then
+        local unit_pos = Entity.GetAbsOrigin(unit)
+        if unit_pos then
+            local distance = unit_pos:Distance(anchor_pos)
+            if distance > runtime.config.follow_distance then
+                MoveToPosition(unit, anchor_pos, agent, now)
+                return
+            end
+        end
+        HoldPosition(unit, agent, now)
+    else
+        HoldPosition(unit, agent, now)
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Unit filtering
+-------------------------------------------------------------------------------
+local function ShouldManageUnit(unit)
+    if not unit or not Entity.IsAlive(unit) then
+        return false
+    end
+
+    if unit == runtime.hero then
+        return false
+    end
+
+    if NPC.IsCourier and NPC.IsCourier(unit) then
+        return false
+    end
+
+    if Entity.GetTeamNum(unit) ~= runtime.team then
+        return false
+    end
+
+    if runtime.player_id and NPC.IsControllableByPlayer and NPC.IsControllableByPlayer(unit, runtime.player_id) then
+        return true
+    end
+
+    local owner_id = GetPlayerOwnerID(unit)
+    if owner_id and runtime.player_id and owner_id == runtime.player_id then
+        return true
+    end
+    if owner_id and runtime.hero_owner_id and owner_id == runtime.hero_owner_id then
+        return true
+    end
+
+    if IsOwnedByHero(unit) then
+        return true
+    end
+
+    return false
+end
+
+-------------------------------------------------------------------------------
+-- Callbacks
+-------------------------------------------------------------------------------
+function agent_script.OnUpdate()
     if not Engine.IsInGame() then
-        reset_state()
+        ResetRuntime()
         return
     end
 
-    local hero = Heroes.GetLocal()
-    if not hero or not Entity.IsAlive(hero) or Entity.IsDormant(hero) or NPC.IsIllusion(hero) then
-        reset_state()
+    EnsureMenu()
+    ReadConfig()
+
+    if not runtime.config.enabled then
+        runtime.agents = {}
         return
     end
 
-    local game_time = GameRules.GetGameTime()
+    if not UpdateHeroContext() then
+        return
+    end
 
-    handle_auto_dominator(hero, game_time)
-    handle_controlled_creeps(hero, game_time)
+    local player = AcquirePlayerHandle()
+    if not player then
+        runtime.agents = {}
+        return
+    end
+
+    local now = GlobalVars.GetCurTime()
+    local next_agents = {}
+
+    for _, unit in ipairs(NPCs.GetAll()) do
+        if ShouldManageUnit(unit) then
+            local handle = Entity.GetIndex(unit)
+            local agent = runtime.agents[handle]
+            if not agent then
+                agent = CreateAgent(unit)
+            end
+            agent.unit = unit
+            agent.handle = handle
+            ProcessAgent(agent, now)
+            next_agents[handle] = agent
+        end
+    end
+
+    runtime.agents = next_agents
 end
 
-return auto_dominator
+function agent_script.OnDraw()
+    if not runtime.config or not runtime.config.debug then
+        return
+    end
+
+    local font = EnsureFont()
+    for _, agent in pairs(runtime.agents) do
+        local unit = agent.unit
+        if unit and Entity.IsAlive(unit) then
+            local origin = Entity.GetAbsOrigin(unit)
+            local offset = NPC.GetHealthBarOffset(unit) or 0
+            if origin then
+                local screen_pos, visible = Render.WorldToScreen(origin + Vector(0, 0, offset + 32))
+                if visible then
+                    local line1 = string.format("[%s]", agent.state or "?")
+                    local line2 = agent.last_action or ""
+                    local color = Color(180, 220, 255, 255)
+                    if agent.state == STATES.MANUAL then
+                        color = Color(255, 165, 0, 255)
+                    elseif agent.state == STATES.ENGAGE then
+                        color = Color(255, 90, 90, 255)
+                    end
+                    local size1 = Render.TextSize(font, 16, line1)
+                    Render.Text(font, 16, line1, Vec2(screen_pos.x - size1.x / 2, screen_pos.y), color)
+                    local size2 = Render.TextSize(font, 14, line2)
+                    Render.Text(font, 14, line2, Vec2(screen_pos.x - size2.x / 2, screen_pos.y + 18), Color(240, 240, 240, 255))
+                end
+            end
+        end
+    end
+end
+
+local function FlagManualControl(unit)
+    if not unit then
+        return
+    end
+    local handle = Entity.GetIndex(unit)
+    local agent = runtime.agents[handle]
+    if agent then
+        agent.manual_until = GlobalVars.GetCurTime() + runtime.config.manual_override
+        agent.state = STATES.MANUAL
+        agent.last_action = "Ручное управление"
+    end
+end
+
+function agent_script.OnPrepareUnitOrders(data)
+    if not runtime.config or not runtime.config.enabled then
+        return true
+    end
+
+    local player = data.player or AcquirePlayerHandle()
+    if not player then
+        return true
+    end
+
+    if data.orderIssuer == Enum.PlayerOrderIssuer.DOTA_ORDER_ISSUER_PASSED_UNIT_ONLY then
+        if data.npc then
+            FlagManualControl(data.npc)
+        end
+        return true
+    end
+
+    local selected = Player.GetSelectedUnits and Player.GetSelectedUnits(player)
+    if selected then
+        for _, unit in ipairs(selected) do
+            FlagManualControl(unit)
+        end
+    end
+
+    return true
+end
+
+function agent_script.OnEntityHurt(data)
+    if not runtime.config or not runtime.config.enabled then
+        return
+    end
+
+    if not data or not data.target or not data.source then
+        return
+    end
+
+    if runtime.hero and data.target == runtime.hero then
+        local idx = Entity.GetIndex(data.source)
+        runtime.threat_expiry[idx] = GlobalVars.GetCurTime() + 3
+    end
+end
+
+function agent_script.OnGameEnd()
+    ResetRuntime()
+end
+
+return agent_script

--- a/script.lua
+++ b/script.lua
@@ -1,1 +1,133 @@
+---@diagnostic disable: undefined-global
 
+local auto_dominator = {}
+
+local DOMINATOR_ITEMS = {
+    "item_helm_of_the_dominator",
+    "item_helm_of_the_overlord",
+}
+
+local BIG_NEUTRAL_NAMES = {
+    npc_dota_neutral_alpha_wolf = true,
+    npc_dota_neutral_centaur_khan = true,
+    npc_dota_neutral_dark_troll_warlord = true,
+    npc_dota_neutral_enraged_wildkin = true,
+    npc_dota_neutral_hellbear_smasher = true,
+    npc_dota_neutral_mud_golem = true,
+    npc_dota_neutral_ogre_bruiser = true,
+    npc_dota_neutral_ogre_magi = true,
+    npc_dota_neutral_polar_furbolg_ursa_warrior = true,
+    npc_dota_neutral_satyr_hellcaller = true,
+    npc_dota_neutral_warpine_raider = true,
+}
+
+local BIG_NEUTRAL_MIN_HEALTH = 700
+local CAST_RANGE_BUFFER = 50
+local ORDER_COOLDOWN = 0.25
+
+local last_cast_time = 0
+
+local function is_big_neutral(npc)
+    if not npc or not Entity.IsNPC(npc) then
+        return false
+    end
+
+    if not Entity.IsAlive(npc) or Entity.IsDormant(npc) then
+        return false
+    end
+
+    if not NPC.IsNeutral(npc) or NPC.IsAncient(npc) then
+        return false
+    end
+
+    local name = NPC.GetUnitName(npc)
+    if name and BIG_NEUTRAL_NAMES[name] then
+        return true
+    end
+
+    local max_health = Entity.GetMaxHealth(npc)
+    if max_health and max_health >= BIG_NEUTRAL_MIN_HEALTH then
+        return true
+    end
+
+    return false
+end
+
+local function get_dominator_item(hero)
+    for _, item_name in ipairs(DOMINATOR_ITEMS) do
+        local item = NPC.GetItem(hero, item_name, true)
+        if item and Ability.IsReady(item) then
+            return item
+        end
+    end
+
+    return nil
+end
+
+local function find_best_target(origin, range)
+    local best_target = nil
+    local best_health = -1
+
+    for _, npc in pairs(NPCs.GetAll()) do
+        if is_big_neutral(npc) then
+            local npc_pos = Entity.GetAbsOrigin(npc)
+            local distance = npc_pos:Distance2D(origin)
+            if distance <= range then
+                local health = Entity.GetHealth(npc) or 0
+                if health > best_health then
+                    best_health = health
+                    best_target = npc
+                end
+            end
+        end
+    end
+
+    return best_target
+end
+
+function auto_dominator.OnUpdate()
+    if not Engine.IsInGame() then
+        return
+    end
+
+    local hero = Heroes.GetLocal()
+    if not hero or not Entity.IsAlive(hero) or Entity.IsDormant(hero) then
+        return
+    end
+
+    if NPC.IsIllusion(hero) or NPC.IsStunned(hero) or NPC.IsChannellingAbility(hero) then
+        return
+    end
+
+    local dominator = get_dominator_item(hero)
+    if not dominator then
+        return
+    end
+
+    local mana = NPC.GetMana(hero)
+    if not Ability.IsCastable(dominator, mana) then
+        return
+    end
+
+    local game_time = GameRules.GetGameTime()
+    if last_cast_time > 0 and (game_time - last_cast_time) < ORDER_COOLDOWN then
+        return
+    end
+
+    local hero_origin = Entity.GetAbsOrigin(hero)
+    local cast_range = Ability.GetCastRange(dominator) or 0
+    if cast_range < 0 then
+        cast_range = 0
+    end
+    cast_range = cast_range + CAST_RANGE_BUFFER
+
+    local target = find_best_target(hero_origin, cast_range)
+    if not target then
+        return
+    end
+
+    Ability.CastTarget(dominator, target)
+    last_cast_time = game_time
+end
+
+return auto_dominator

--- a/script.lua
+++ b/script.lua
@@ -24,8 +24,151 @@ local BIG_NEUTRAL_NAMES = {
 local BIG_NEUTRAL_MIN_HEALTH = 700
 local CAST_RANGE_BUFFER = 50
 local ORDER_COOLDOWN = 0.25
+local FOLLOW_ORDER_INTERVAL = 0.75
+local FOLLOW_DISTANCE_LEASH = 250
+local ABILITY_ORDER_COOLDOWN = 0.6
+local NO_TARGET_FALLBACK_RANGE = 350
+
+local SPECIAL_VALUE_KEYS = {
+    "radius",
+    "range",
+    "max_distance",
+    "distance",
+    "cast_range",
+    "cast_radius",
+    "aoe",
+    "area_of_effect",
+}
+
+local ABILITY_RULES = {
+    centaur_khan_war_stomp = { cast = "no_target", range = 325 },
+    hellbear_smasher_thunder_clap = { cast = "no_target", range = 350 },
+    polar_furbolg_ursa_warrior_thunder_clap = { cast = "no_target", range = 350 },
+    dark_troll_warlord_ensnare = { cast = "target", range = 550, allow_zero_damage = true },
+    satyr_hellcaller_shockwave = { cast = "point", range = 950 },
+    mudgolem_hurl_boulder = { cast = "target", range = 800 },
+    rock_golem_hurl_boulder = { cast = "target", range = 800 },
+    greater_mudgolem_hurl_boulder = { cast = "target", range = 800 },
+    greater_rock_golem_hurl_boulder = { cast = "target", range = 800 },
+    warpine_raider_seed_shot = { cast = "target", range = 600 },
+    ogre_bruiser_ogre_smash = { cast = "point", range = 275 },
+    black_dragon_fireball = { cast = "point", range = 1200 },
+    ancient_black_dragon_fireball = { cast = "point", range = 1200 },
+    granite_golem_hurl_boulder = { cast = "target", range = 900 },
+    ancient_rock_golem_hurl_boulder = { cast = "target", range = 900 },
+    ancient_thunderhide_slam = { cast = "no_target", range = 325 },
+}
+
+local NO_TARGET_WHITELIST = {
+    centaur_khan_war_stomp = true,
+    hellbear_smasher_thunder_clap = true,
+    polar_furbolg_ursa_warrior_thunder_clap = true,
+    ancient_thunderhide_slam = true,
+}
+
+local ABILITY_BLACKLIST = {
+    dark_troll_warlord_raise_dead = true,
+    enraged_wildkin_tornado = true,
+    ogre_magi_frost_armor = true,
+    ancient_thunderhide_frenzy = true,
+}
 
 local last_cast_time = 0
+local creep_states = {}
+local ability_last_cast_times = {}
+
+local band = bit32 and bit32.band or (bit and bit.band)
+
+local function has_flag(value, flag)
+    if not value or not flag then
+        return false
+    end
+
+    if band then
+        return band(value, flag) ~= 0
+    end
+
+    while value > 0 and flag > 0 do
+        if value % 2 == 1 and flag % 2 == 1 then
+            return true
+        end
+
+        value = math.floor(value / 2)
+        flag = math.floor(flag / 2)
+    end
+
+    return false
+end
+
+local function reset_state()
+    last_cast_time = 0
+    creep_states = {}
+    ability_last_cast_times = {}
+end
+
+local function get_creep_state(index)
+    local state = creep_states[index]
+    if not state then
+        state = { last_follow = 0 }
+        creep_states[index] = state
+    end
+
+    return state
+end
+
+local function cleanup_creep_states(active_indices)
+    for index in pairs(creep_states) do
+        if not active_indices[index] then
+            creep_states[index] = nil
+        end
+    end
+end
+
+local function record_ability_cast(ability, game_time)
+    local idx = Ability.GetIndex(ability)
+    if idx then
+        ability_last_cast_times[idx] = game_time
+    end
+end
+
+local function can_cast_now(ability, game_time)
+    local idx = Ability.GetIndex(ability)
+    if not idx then
+        return true
+    end
+
+    local last = ability_last_cast_times[idx]
+    if last and (game_time - last) < ABILITY_ORDER_COOLDOWN then
+        return false
+    end
+
+    return true
+end
+
+local function get_special_value(ability, key)
+    local ok, value = pcall(Ability.GetLevelSpecialValueFor, ability, key, -1)
+    if ok and type(value) == "number" then
+        return value
+    end
+
+    return nil
+end
+
+local function get_effective_range(ability, fallback)
+    local range = Ability.GetCastRange(ability)
+    if range and range > 0 then
+        return range
+    end
+
+    for _, key in ipairs(SPECIAL_VALUE_KEYS) do
+        local value = get_special_value(ability, key)
+        if value and value > 0 then
+            return value
+        end
+    end
+
+    return fallback
+end
 
 local function is_big_neutral(npc)
     if not npc or not Entity.IsNPC(npc) then
@@ -85,17 +228,202 @@ local function find_best_target(origin, range)
     return best_target
 end
 
-function auto_dominator.OnUpdate()
-    if not Engine.IsInGame() then
-        return
+local function collect_enemy_heroes(hero)
+    local enemies = {}
+
+    for _, enemy in pairs(Heroes.GetAll()) do
+        if enemy ~= hero and Entity.IsAlive(enemy) and not Entity.IsDormant(enemy) and not Entity.IsSameTeam(hero, enemy) then
+            table.insert(enemies, enemy)
+        end
     end
 
-    local hero = Heroes.GetLocal()
-    if not hero or not Entity.IsAlive(hero) or Entity.IsDormant(hero) then
-        return
+    return enemies
+end
+
+local function is_controlled_creep(hero, npc, player_id)
+    if npc == hero then
+        return false
     end
 
-    if NPC.IsIllusion(hero) or NPC.IsStunned(hero) or NPC.IsChannellingAbility(hero) then
+    if not npc or not Entity.IsNPC(npc) or Entity.IsDormant(npc) or not Entity.IsAlive(npc) then
+        return false
+    end
+
+    if NPC.IsHero(npc) or NPC.IsIllusion(npc) then
+        return false
+    end
+
+    local is_creep = NPC.IsCreep(npc)
+    local is_ancient = NPC.IsAncient(npc)
+    if not is_creep and not is_ancient then
+        return false
+    end
+
+    if NPC.IsLaneCreep(npc) then
+        return false
+    end
+
+    if not Entity.IsSameTeam(hero, npc) then
+        return false
+    end
+
+    if player_id and player_id >= 0 and not NPC.IsControllableByPlayer(npc, player_id) then
+        return false
+    end
+
+    return true
+end
+
+local function collect_controlled_creeps(hero)
+    local player = Players.GetLocal()
+    local player_id = nil
+
+    if player then
+        player_id = Player.GetPlayerID(player)
+        if player_id and player_id < 0 then
+            player_id = nil
+        end
+    end
+
+    local creeps = {}
+    local active_indices = {}
+
+    for _, npc in pairs(NPCs.GetAll()) do
+        if is_controlled_creep(hero, npc, player_id) then
+            table.insert(creeps, npc)
+            active_indices[Entity.GetIndex(npc)] = true
+        end
+    end
+
+    cleanup_creep_states(active_indices)
+
+    return creeps
+end
+
+local function find_enemy_in_range(enemies, source_pos, range)
+    local best_target = nil
+    local best_distance = math.huge
+
+    for _, enemy in ipairs(enemies) do
+        if not NPC.IsIllusion(enemy) then
+            local enemy_pos = Entity.GetAbsOrigin(enemy)
+            local distance = enemy_pos:Distance2D(source_pos)
+            if distance <= range and distance < best_distance then
+                best_target = enemy
+                best_distance = distance
+            end
+        end
+    end
+
+    return best_target, best_distance
+end
+
+local function cast_creep_ability(creep, ability, enemies, game_time)
+    if not ability then
+        return false
+    end
+
+    local ability_name = Ability.GetName(ability)
+    if not ability_name or ABILITY_BLACKLIST[ability_name] then
+        return false
+    end
+
+    if Ability.GetLevel(ability) <= 0 or Ability.IsHidden(ability) or not Ability.IsActivated(ability) then
+        return false
+    end
+
+    if not Ability.IsReady(ability) or not Ability.IsOwnersManaEnough(ability) or not can_cast_now(ability, game_time) then
+        return false
+    end
+
+    local behavior = Ability.GetBehavior(ability)
+    if has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_PASSIVE) then
+        return false
+    end
+
+    if has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_CHANNELLED) then
+        return false
+    end
+
+    local config = ABILITY_RULES[ability_name]
+    local cast_type = config and config.cast
+
+    if not cast_type then
+        if has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_UNIT_TARGET) then
+            cast_type = "target"
+        elseif has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_POINT) then
+            cast_type = "point"
+        elseif has_flag(behavior, Enum.AbilityBehavior.DOTA_ABILITY_BEHAVIOR_NO_TARGET) then
+            cast_type = "no_target"
+        else
+            return false
+        end
+    end
+
+    local target_team = Ability.GetTargetTeam(ability)
+    if (cast_type == "target" or cast_type == "point")
+        and target_team ~= Enum.TargetTeam.DOTA_UNIT_TARGET_TEAM_ENEMY
+        and target_team ~= Enum.TargetTeam.DOTA_UNIT_TARGET_TEAM_BOTH then
+        return false
+    end
+
+    if cast_type == "target" and (not config or not config.allow_zero_damage) then
+        local damage = Ability.GetDamage(ability)
+        if not damage or damage <= 0 then
+            return false
+        end
+    end
+
+    if cast_type == "no_target" and not (config or NO_TARGET_WHITELIST[ability_name]) then
+        local damage = Ability.GetDamage(ability)
+        if not damage or damage <= 0 then
+            return false
+        end
+    end
+
+    local fallback = cast_type == "no_target" and NO_TARGET_FALLBACK_RANGE or 700
+    local range = config and config.range or get_effective_range(ability, fallback)
+    if not range or range <= 0 then
+        range = fallback
+    end
+
+    local creep_pos = Entity.GetAbsOrigin(creep)
+
+    if cast_type == "target" then
+        if range < 0 then
+            range = 0
+        end
+        local target = find_enemy_in_range(enemies, creep_pos, range)
+        if target then
+            Ability.CastTarget(ability, target)
+            record_ability_cast(ability, game_time)
+            return true
+        end
+    elseif cast_type == "point" then
+        local target = find_enemy_in_range(enemies, creep_pos, range)
+        if target then
+            local pos = Entity.GetAbsOrigin(target)
+            Ability.CastPosition(ability, pos)
+            record_ability_cast(ability, game_time)
+            return true
+        end
+    elseif cast_type == "no_target" then
+        local radius = range > 0 and range or NO_TARGET_FALLBACK_RANGE
+        for _, enemy in ipairs(enemies) do
+            local enemy_pos = Entity.GetAbsOrigin(enemy)
+            if enemy_pos:Distance2D(creep_pos) <= radius then
+                Ability.CastNoTarget(ability)
+                record_ability_cast(ability, game_time)
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+local function handle_auto_dominator(hero, game_time)
+    if NPC.IsStunned(hero) or NPC.IsChannellingAbility(hero) then
         return
     end
 
@@ -109,7 +437,6 @@ function auto_dominator.OnUpdate()
         return
     end
 
-    local game_time = GameRules.GetGameTime()
     if last_cast_time > 0 and (game_time - last_cast_time) < ORDER_COOLDOWN then
         return
     end
@@ -128,6 +455,63 @@ function auto_dominator.OnUpdate()
 
     Ability.CastTarget(dominator, target)
     last_cast_time = game_time
+end
+
+local function handle_controlled_creeps(hero, game_time)
+    local creeps = collect_controlled_creeps(hero)
+    if #creeps == 0 then
+        return
+    end
+
+    local enemies = collect_enemy_heroes(hero)
+    local hero_pos = Entity.GetAbsOrigin(hero)
+
+    for _, creep in ipairs(creeps) do
+        local index = Entity.GetIndex(creep)
+        local state = get_creep_state(index)
+
+        if state then
+            local creep_pos = Entity.GetAbsOrigin(creep)
+            if creep_pos:Distance2D(hero_pos) > FOLLOW_DISTANCE_LEASH then
+                if game_time - (state.last_follow or 0) >= FOLLOW_ORDER_INTERVAL then
+                    NPC.MoveTo(creep, hero_pos)
+                    state.last_follow = game_time
+                end
+            end
+        end
+
+        local can_use_abilities = #enemies > 0
+            and not NPC.IsStunned(creep)
+            and not NPC.IsSilenced(creep)
+            and not NPC.IsChannellingAbility(creep)
+
+        if can_use_abilities then
+            for slot = 0, 5 do
+                local ability = NPC.GetAbilityByIndex(creep, slot)
+                if cast_creep_ability(creep, ability, enemies, game_time) then
+                    break
+                end
+            end
+        end
+    end
+end
+
+function auto_dominator.OnUpdate()
+    if not Engine.IsInGame() then
+        reset_state()
+        return
+    end
+
+    local hero = Heroes.GetLocal()
+    if not hero or not Entity.IsAlive(hero) or Entity.IsDormant(hero) or NPC.IsIllusion(hero) then
+        reset_state()
+        return
+    end
+
+    local game_time = GameRules.GetGameTime()
+
+    handle_auto_dominator(hero, game_time)
+    handle_controlled_creeps(hero, game_time)
 end
 
 return auto_dominator


### PR DESCRIPTION
## Summary
- add an OnUpdate handler that autocasts Helm of the Dominator or Overlord when ready
- restrict targets to alive neutral large creeps within cast range, prioritising the healthiest option
- prevent repeated casts by tracking timing and skipping when the hero is unable to act

## Testing
- not run (script logic only)


------
https://chatgpt.com/codex/tasks/task_e_68e439136804832184b7696f7c9ed545